### PR TITLE
fix(gost): implement failover for multi-node forwarding rules

### DIFF
--- a/go-gost/x/ctx/value.go
+++ b/go-gost/x/ctx/value.go
@@ -109,3 +109,23 @@ func LoggerFromContext(ctx context.Context) logger.Logger {
 	v, _ := ctx.Value(keyLogger).(logger.Logger)
 	return v
 }
+
+// excludeNodesKey saves the list of node addresses to exclude during selection.
+// This is used for failover retry logic - when a node fails, it gets added to
+// the exclude list so the next Select() call will skip it.
+type excludeNodesKey struct{}
+
+var (
+	keyExcludeNodes = &excludeNodesKey{}
+)
+
+// ContextWithExcludeNodes returns a context with the list of node addresses to exclude.
+func ContextWithExcludeNodes(ctx context.Context, nodes []string) context.Context {
+	return context.WithValue(ctx, keyExcludeNodes, nodes)
+}
+
+// ExcludeNodesFromContext returns the list of node addresses to exclude from selection.
+func ExcludeNodesFromContext(ctx context.Context) []string {
+	v, _ := ctx.Value(keyExcludeNodes).([]string)
+	return v
+}

--- a/go-gost/x/handler/forward/local/metadata.go
+++ b/go-gost/x/handler/forward/local/metadata.go
@@ -25,6 +25,12 @@ type metadata struct {
 	privateKey  crypto.PrivateKey
 	alpn        string
 	mitmBypass  bypass.Bypass
+
+	// maxRetries specifies the maximum number of failover retry attempts.
+	// When a target node fails, the handler will try the next available node.
+	// 0 means use the total number of available nodes (try all nodes once).
+	// Default: 0 (try all available nodes)
+	maxRetries int
 }
 
 func (h *forwardHandler) parseMetadata(md mdata.Metadata) (err error) {
@@ -55,6 +61,9 @@ func (h *forwardHandler) parseMetadata(md mdata.Metadata) (err error) {
 	}
 	h.md.alpn = mdutil.GetString(md, "mitm.alpn")
 	h.md.mitmBypass = registry.BypassRegistry().Get(mdutil.GetString(md, "mitm.bypass"))
+
+	// maxRetries: 0 means try all available nodes (default behavior)
+	h.md.maxRetries = mdutil.GetInt(md, "maxRetries", "retry.max")
 
 	return
 }

--- a/go-gost/x/handler/forward/remote/metadata.go
+++ b/go-gost/x/handler/forward/remote/metadata.go
@@ -26,6 +26,12 @@ type metadata struct {
 	privateKey  crypto.PrivateKey
 	alpn        string
 	mitmBypass  bypass.Bypass
+
+	// maxRetries specifies the maximum number of failover retry attempts.
+	// When a target node fails, the handler will try the next available node.
+	// 0 means use the total number of available nodes (try all nodes once).
+	// Default: 0 (try all available nodes)
+	maxRetries int
 }
 
 func (h *forwardHandler) parseMetadata(md mdata.Metadata) (err error) {
@@ -57,5 +63,9 @@ func (h *forwardHandler) parseMetadata(md mdata.Metadata) (err error) {
 	}
 	h.md.alpn = mdutil.GetString(md, "mitm.alpn")
 	h.md.mitmBypass = registry.BypassRegistry().Get(mdutil.GetString(md, "mitm.bypass"))
+
+	// maxRetries: 0 means try all available nodes (default behavior)
+	h.md.maxRetries = mdutil.GetInt(md, "maxRetries", "retry.max")
+
 	return
 }

--- a/go-gost/x/selector/filter.go
+++ b/go-gost/x/selector/filter.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/go-gost/core/metadata"
-	mdutil "github.com/go-gost/x/metadata/util"
 	"github.com/go-gost/core/selector"
+	mdutil "github.com/go-gost/x/metadata/util"
 )
 
 type failFilter[T any] struct {
@@ -24,10 +24,11 @@ func FailFilter[T any](maxFails int, timeout time.Duration) selector.Filter[T] {
 }
 
 // Filter filters dead objects.
+// Note: We intentionally do NOT skip filtering when len(vs) <= 1.
+// This ensures that even a single dead node gets filtered out,
+// allowing the caller to know that no healthy nodes are available
+// and potentially trigger failover behavior.
 func (f *failFilter[T]) Filter(ctx context.Context, vs ...T) []T {
-	if len(vs) <= 1 {
-		return vs
-	}
 	var l []T
 	for _, v := range vs {
 		maxFails := f.maxFails


### PR DESCRIPTION
## Summary

Fixes #12 - 转发负载不会故障转移 (Forwarding load does not failover)

When a forwarding rule has multiple backend nodes configured, the first node failure would cause the entire forward to fail instead of trying the next available node.

## Root Causes Fixed

1. **FailFilter skipped single-node filtering** (`selector/filter.go`): When only 1 node remained, filter returned early without checking if it was marked as failed
2. **hop.Select() bypassed selector** (`hop/hop.go`): Single-node hops skipped the selector entirely, never triggering FailFilter
3. **No retry logic in handlers**: Handlers only attempted one node and returned error on failure

## Changes

| File | Change |
|------|--------|
| `x/selector/filter.go` | Remove `len(vs) <= 1` early return - always filter failed nodes |
| `x/hop/hop.go` | Remove single-node bypass, add ExcludeNodes context support |
| `x/ctx/value.go` | Add `ContextWithExcludeNodes()` and `ExcludeNodesFromContext()` helpers |
| `x/handler/forward/local/metadata.go` | Add `maxRetries` config field |
| `x/handler/forward/local/handler.go` | Implement retry loop with node exclusion |
| `x/handler/forward/remote/metadata.go` | Add `maxRetries` config field |
| `x/handler/forward/remote/handler.go` | Implement retry loop with node exclusion |
| `x/internal/util/forwarder/sniffer.go` | Add retry logic to `dial()` and `dialTLS()` |

## How It Works Now

1. When a connection to a node fails, the node is marked as failed via `marker.Mark()`
2. The handler adds the failed node to an exclusion list via context
3. On retry, `hop.Select()` reads the exclusion list and skips those nodes
4. `FailFilter` also filters out nodes that are marked as failed
5. Process continues until a healthy node is found or all nodes exhausted

## Testing

- [x] Build passes (`go build .`)
- [x] Binary runs without crashes
- [ ] Manual testing with multi-node forwarding rule (requires deployment)

## Configuration

The retry behavior is automatic based on the number of nodes in the hop. Optionally, `maxRetries` can be configured in handler metadata to limit retry attempts.