### PR TITLE
feat(gost): add debug logging for failover mechanism analysis

### DIFF
--- a/go-gost/x/hop/hop.go
+++ b/go-gost/x/hop/hop.go
@@ -149,6 +149,9 @@ func (p *chainHop) Select(ctx context.Context, opts ...hop.SelectOption) *chain.
 		excludeSet[addr] = true
 	}
 
+	// Debug logging for failover analysis
+	log.Debugf("[hop.Select] excludeNodes=%v, totalNodes=%d", excludeNodes, len(p.Nodes()))
+
 	var nodes []*chain.Node
 	for _, node := range p.Nodes() {
 		if node == nil {
@@ -213,7 +216,9 @@ func (p *chainHop) Select(ctx context.Context, opts ...hop.SelectOption) *chain.
 	// FailFilter will exclude recently-failed nodes, allowing traffic to
 	// be routed to healthy alternatives.
 	if s := p.options.selector; s != nil {
+		log.Debugf("[hop.Select] calling selector.Select with %d nodes", len(nodes))
 		if node := s.Select(ctx, nodes...); node != nil {
+			log.Debugf("[hop.Select] selected node=%s addr=%s", node.Name, node.Addr)
 			return node
 		}
 		// All nodes filtered out by FailFilter - all are marked as failed.


### PR DESCRIPTION
## Summary
- Add debug logs to FailFilter.Filter() to trace node filtering decisions
- Add debug logs to hop.Select() to track excludeNodes and selection results  
- Add debug logs to handler retry loop to monitor failover attempts

## Purpose
These logs help diagnose issues where failover between multiple target nodes is not working as expected.

## Files Changed
- `go-gost/x/selector/filter.go`
- `go-gost/x/hop/hop.go`
- `go-gost/x/handler/forward/local/handler.go`