### PR TITLE
fix(backend): enable noDelay for relay connector to fix chain failover

### DIFF
--- a/springboot-backend/src/main/java/com/admin/common/utils/GostUtil.java
+++ b/springboot-backend/src/main/java/com/admin/common/utils/GostUtil.java
@@ -51,6 +51,10 @@ public class GostUtil {
 
             JSONObject connector = new JSONObject();
             connector.put("type", "relay");
+            // 启用 noDelay 以确保连接错误能立即传播，使故障转移正常工作
+            JSONObject connectorMetadata = new JSONObject();
+            connectorMetadata.put("nodelay", true);
+            connector.put("metadata", connectorMetadata);
 
             Node node_info = node_s.get(chainTunnel.getNodeId());
             JSONObject node = new JSONObject();


### PR DESCRIPTION
When using relay connector with noDelay=false (default), connection errors are deferred until first read/write. This prevents the forwarder marker from being called, causing failover to never trigger.

Setting nodelay=true ensures connection errors propagate immediately, allowing proper failover behavior when chain targets are unreachable.