### PR TITLE
fix(gost): process WebSocket commands concurrently to prevent diagnos…

### DIFF
--- a/go-gost/x/socket/config.go
+++ b/go-gost/x/socket/config.go
@@ -2,11 +2,17 @@ package socket
 
 import (
 	"os"
+	"sync"
 
 	"github.com/go-gost/x/config"
 )
 
+// configMutex 保护配置文件的并发写入
+var configMutex sync.Mutex
+
 func saveConfig() {
+	configMutex.Lock()
+	defer configMutex.Unlock()
 
 	file := "gost.json"
 


### PR DESCRIPTION
…is timeouts

When multiple TcpPing requests are sent in parallel for diagnosing multiple remote addresses, the Go agent was processing them serially. This caused later requests to timeout (10s) while waiting for earlier requests to complete.

Changes:
- Run routeCommand in goroutines for parallel command execution
- Add mutex to saveConfig() to protect concurrent file writes