### PR TITLE
feat(install): support version-pinned install from release assets

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -268,6 +268,10 @@ jobs:
           sed -i "s|2.0.7-beta|${VERSION}|g" ./artifacts/install.sh
           sed -i "s|2.0.7-beta|${VERSION}|g" ./artifacts/panel_install.sh
 
+          # 注入固定版本号，使从 Release 页下载的脚本只安装该版本
+          sed -i "s|^PINNED_VERSION=\"\"|PINNED_VERSION=\"${VERSION}\"|" ./artifacts/install.sh
+          sed -i "s|^PINNED_VERSION=\"\"|PINNED_VERSION=\"${VERSION}\"|" ./artifacts/panel_install.sh
+
       - name: Create Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -303,14 +307,22 @@ jobs:
 
           ## 🚀 Quick Install
 
-          **Panel:**
+          **Panel (安装此版本 ${VERSION}):**
           \`\`\`bash
           curl -L https://github.com/${{ github.repository }}/releases/download/${VERSION}/panel_install.sh -o panel_install.sh && chmod +x panel_install.sh && ./panel_install.sh
           \`\`\`
 
-          **Node:**
+          **Node (安装此版本 ${VERSION}):**
           \`\`\`bash
           curl -L https://github.com/${{ github.repository }}/releases/download/${VERSION}/install.sh -o install.sh && chmod +x install.sh && ./install.sh
+          \`\`\`
+
+          **安装最新版:**
+          \`\`\`bash
+          # 面板端
+          curl -L https://raw.githubusercontent.com/${{ github.repository }}/main/panel_install.sh -o panel_install.sh && chmod +x panel_install.sh && ./panel_install.sh
+          # 节点端
+          curl -L https://raw.githubusercontent.com/${{ github.repository }}/main/install.sh -o install.sh && chmod +x install.sh && ./install.sh
           \`\`\`" \
             --repo ${{ github.repository }}
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following major changes and additions have been made in this fork (FLVX):
 ## 部署流程
 ---
 ### Docker Compose部署
-#### 快速部署
+#### 快速部署（安装最新版）
 面板端：
 ```bash
 curl -L https://raw.githubusercontent.com/Sagit-chu/flux-panel/main/panel_install.sh -o panel_install.sh && chmod +x panel_install.sh && ./panel_install.sh
@@ -52,6 +52,18 @@ curl -L https://raw.githubusercontent.com/Sagit-chu/flux-panel/main/panel_instal
 节点端：
 ```bash
 curl -L https://raw.githubusercontent.com/Sagit-chu/flux-panel/main/install.sh -o install.sh && chmod +x install.sh && ./install.sh
+```
+
+#### 安装特定版本
+从 [Releases](https://github.com/Sagit-chu/flux-panel/releases) 页面复制对应版本的安装命令，脚本会自动安装该版本而非最新版。
+
+面板端（以 2.1.0 为例）：
+```bash
+curl -L https://github.com/Sagit-chu/flux-panel/releases/download/2.1.0/panel_install.sh -o panel_install.sh && chmod +x panel_install.sh && ./panel_install.sh
+```
+节点端（以 2.1.0 为例）：
+```bash
+curl -L https://github.com/Sagit-chu/flux-panel/releases/download/2.1.0/install.sh -o install.sh && chmod +x install.sh && ./install.sh
 ```
 
 #### 默认管理员账号

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,9 @@
 # GitHub repo used for release downloads
 REPO="Sagit-chu/flux-panel"
 
+# 固定版本号（Release 构建时自动填充，留空则获取最新版）
+PINNED_VERSION=""
+
 # 获取系统架构
 get_architecture() {
     ARCH=$(uname -m)
@@ -83,6 +86,10 @@ resolve_version() {
   fi
   if [[ -n "${FLUX_VERSION:-}" ]]; then
     echo "$FLUX_VERSION"
+    return 0
+  fi
+  if [[ -n "${PINNED_VERSION:-}" ]]; then
+    echo "$PINNED_VERSION"
     return 0
   fi
 

--- a/panel_install.sh
+++ b/panel_install.sh
@@ -10,6 +10,9 @@ export LC_ALL=C
 # GitHub repo used for release downloads
 REPO="Sagit-chu/flux-panel"
 
+# 固定版本号（Release 构建时自动填充，留空则获取最新版）
+PINNED_VERSION=""
+
 COUNTRY=$(curl -s https://ipinfo.io/country)
 
 maybe_proxy_url() {
@@ -67,6 +70,10 @@ resolve_version() {
   fi
   if [[ -n "${FLUX_VERSION:-}" ]]; then
     echo "$FLUX_VERSION"
+    return 0
+  fi
+  if [[ -n "${PINNED_VERSION:-}" ]]; then
+    echo "$PINNED_VERSION"
     return 0
   fi
 


### PR DESCRIPTION
Add PINNED_VERSION mechanism so scripts downloaded from a specific release (e.g. 2.1.0) install that exact version instead of latest. CI injects the version via sed during release build. Users can still override with VERSION= env var. Update release notes and README to show both pinned and latest install options.