### PR TITLE
fix(frontend): remove deep blue focus border

### DIFF
--- a/vite-frontend/src/styles/globals.css
+++ b/vite-frontend/src/styles/globals.css
@@ -51,8 +51,8 @@ html, body {
 }
 
 [data-slot="input-wrapper"]:focus-within:not([data-invalid="true"]) {
-  border-color: rgb(59 130 246);
   outline: 2px solid rgb(59 130 246 / 35%);
+  outline-offset: 1px;
 }
 
 .safe-top {


### PR DESCRIPTION
## Summary
- Removed explicit `border-color` from input focus state to eliminate unwanted deep blue inner line.
- Added `outline-offset: 1px` to maintain accessible focus visibility without conflicting with design.