### PR TITLE
fix(frontend): force remove input focus border and ring

### DIFF
--- a/vite-frontend/src/styles/globals.css
+++ b/vite-frontend/src/styles/globals.css
@@ -50,7 +50,6 @@ html, body {
   box-shadow: none;
 }
 
-<<<<<<< HEAD
 [data-slot="input-wrapper"]:focus-within:not([data-invalid="true"]),
 [data-slot="input-wrapper"][data-focus="true"]:not([data-invalid="true"]),
 [data-slot="input-wrapper"][data-focused="true"]:not([data-invalid="true"]) {
@@ -58,12 +57,6 @@ html, body {
   outline: none !important;
   outline-offset: 0 !important;
   box-shadow: none !important;
-=======
-[data-slot="input-wrapper"]:focus-within:not([data-invalid="true"]) {
-  outline: none;
-  outline-offset: 0;
-  box-shadow: none;
->>>>>>> origin/main
 }
 
 .safe-top {


### PR DESCRIPTION
More aggressively removes the blue border and ring on input focus using !important and additional selectors for HeroUI components.