### PR TITLE
fix(frontend): aggressive removal of input focus styles

### DIFF
--- a/vite-frontend/src/styles/globals.css
+++ b/vite-frontend/src/styles/globals.css
@@ -59,6 +59,12 @@ html, body {
   box-shadow: none !important;
 }
 
+[data-slot="input-wrapper"] input:focus {
+  outline: none !important;
+  box-shadow: none !important;
+  border-color: transparent !important;
+}
+
 .safe-top {
   padding-top: var(--safe-area-top);
 }


### PR DESCRIPTION
Adds specific CSS rules to target inner input elements and forcefully remove outline, ring, and border colors on focus, per user feedback.