### PR TITLE
fix(backend): correct federation port forwarding tunnel type handling

### DIFF
--- a/go-backend/internal/http/handler/federation.go
+++ b/go-backend/internal/http/handler/federation.go
@@ -780,9 +780,6 @@ func (h *Handler) federationTunnelCreate(w http.ResponseWriter, r *http.Request)
 	}
 
 	tunnelType := 1
-	if strings.ToLower(req.Protocol) == "udp" {
-		tunnelType = 2
-	}
 
 	tx, err := h.repo.DB().Begin()
 	if err != nil {

--- a/go-backend/internal/http/handler/mutations.go
+++ b/go-backend/internal/http/handler/mutations.go
@@ -569,12 +569,10 @@ func (h *Handler) tunnelCreate(w http.ResponseWriter, r *http.Request) {
 	runtimeState.TunnelID = tunnelID
 	var federationBindings []sqlite.FederationTunnelBinding
 	var federationReleaseRefs []federationRuntimeReleaseRef
-	if typeVal == 2 {
-		federationBindings, federationReleaseRefs, err = h.applyFederationRuntime(runtimeState)
-		if err != nil {
-			response.WriteJSON(w, response.ErrDefault(err.Error()))
-			return
-		}
+	federationBindings, federationReleaseRefs, err = h.applyFederationRuntime(runtimeState)
+	if err != nil {
+		response.WriteJSON(w, response.ErrDefault(err.Error()))
+		return
 	}
 	applyTunnelPortsToRequest(req, runtimeState)
 	if err := replaceTunnelChainsTx(tx, tunnelID, req); err != nil {
@@ -693,12 +691,10 @@ func (h *Handler) tunnelUpdate(w http.ResponseWriter, r *http.Request) {
 
 	var federationBindings []sqlite.FederationTunnelBinding
 	var federationReleaseRefs []federationRuntimeReleaseRef
-	if typeVal == 2 {
-		federationBindings, federationReleaseRefs, err = h.applyFederationRuntime(runtimeState)
-		if err != nil {
-			response.WriteJSON(w, response.ErrDefault(err.Error()))
-			return
-		}
+	federationBindings, federationReleaseRefs, err = h.applyFederationRuntime(runtimeState)
+	if err != nil {
+		response.WriteJSON(w, response.ErrDefault(err.Error()))
+		return
 	}
 	applyTunnelPortsToRequest(req, runtimeState)
 
@@ -2340,7 +2336,7 @@ func (h *Handler) federationLocalDomain() string {
 func (h *Handler) applyFederationRuntime(state *tunnelCreateState) ([]sqlite.FederationTunnelBinding, []federationRuntimeReleaseRef, error) {
 	bindings := make([]sqlite.FederationTunnelBinding, 0)
 	releaseRefs := make([]federationRuntimeReleaseRef, 0)
-	if h == nil || state == nil || state.Type != 2 {
+	if h == nil || state == nil {
 		return bindings, releaseRefs, nil
 	}
 	fc := client.NewFederationClient()


### PR DESCRIPTION
## Summary

Fixes two critical bugs in federation mode port forwarding:

### Bug 1: Type 1 tunnels not applying federation runtime
- **Issue**: Port forwarding (Type 1) tunnels were not calling `applyFederationRuntime`
- **Impact**: Port forwarding tunnels were not properly configured in federation mode
- **Fix**: Removed the `typeVal == 2` condition to apply federation runtime to all tunnel types

### Bug 2: UDP tunnels incorrectly set to Type 2
- **Issue**: UDP tunnels were being incorrectly set to Type 2 in `federationTunnelCreate`
- **Impact**: Conflicted with federation runtime logic that expects Type 1 for port forwarding
- **Fix**: Removed the UDP-specific type override logic

## Changes
- `go-backend/internal/http/handler/mutations.go`: Apply federation runtime to all tunnel types in `tunnelCreate` and `tunnelUpdate`
- `go-backend/internal/http/handler/federation.go`: Remove UDP type override in `federationTunnelCreate`

## Testing
These changes ensure all tunnel types are properly handled in federation mode with correct runtime configuration applied.