### PR TITLE
fix(tunnel): respect IPv6 preference in tunnel creation and diagnostics

### DIFF
--- a/.sisyphus/ralph-loop.local.md
+++ b/.sisyphus/ralph-loop.local.md
@@ -1,9 +1,0 @@
----
-active: true
-iteration: 1
-max_iterations: 100
-completion_promise: "DONE"
-started_at: "2026-02-15T16:38:58.212Z"
-session_id: "ses_39dd49703ffeveg711aA1D1YAk"
----
-现状后端数据库兼容sqlite和postgresql，每一次新增功能需要维护两套数据库sql，需求是使用一个数据库驱动能同时兼容两个数据库，请仔细分析，列出计划，全量迁移，并且写好所有的测试，确保重构后所有的功能都能正常运行，由于工程量大，请写一个计划列表的markdown记录，每次完成一个就记录一下进度


### PR DESCRIPTION
## Summary
- **Fix 1 (mutations.go)**:  now accepts  and prioritizes IPv6 addresses when 'v6' is selected.
- **Fix 2 (control_plane.go)**:  now passes  down to .
- **Fix 3 (control_plane.go)**:  uses  logic to pick the correct IP version instead of hardcoded  fallback.

This ensures dual-stack nodes respect the user's IP preference setting both during tunnel creation (InNodes list order) and diagnostic pings.