### PR TITLE
fix(tunnel): sync forwards to agents after tunnel update

### DIFF
--- a/go-backend/internal/http/handler/mutations.go
+++ b/go-backend/internal/http/handler/mutations.go
@@ -696,6 +696,12 @@ func (h *Handler) tunnelUpdate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if forwards, fwdErr := h.listForwardsByTunnel(id); fwdErr == nil {
+		for i := range forwards {
+			_ = h.syncForwardServices(&forwards[i], "UpdateService", true)
+		}
+	}
+
 	response.WriteJSON(w, response.OKEmpty())
 }
 


### PR DESCRIPTION
## 问题

编辑隧道（如新增入口节点）后，已绑定该隧道的转发配置不会自动下发到 Agent，导致 Agent 仍运行旧配置。用户必须手动再保存一次转发才能生效。

Closes #135

## 根因

`tunnelUpdate` 处理器在更新隧道并调用 `applyTunnelRuntime` 后，没有对绑定该隧道的所有 forward 调用 `syncForwardServices`，而 `tunnelBatchRedeploy` 有这一步骤。

## 修复

在 `tunnelUpdate` 成功返回前，复用 `listForwardsByTunnel` + `syncForwardServices` 的现有模式（与 `tunnelBatchRedeploy` 保持一致），将新的入口配置实时下发给 Agent。

```go
if forwards, fwdErr := h.listForwardsByTunnel(id); fwdErr == nil {
    for i := range forwards {
        _ = h.syncForwardServices(&forwards[i], "UpdateService", true)
    }
}
```

## 测试

- `go build ./...` ✅
- `go test ./...` ✅（handler、repo、contract 全部通过）