### PR TITLE
fix(backend): respect v6 preference in forward diagnosis

### DIFF
--- a/go-backend/internal/http/handler/control_plane.go
+++ b/go-backend/internal/http/handler/control_plane.go
@@ -360,6 +360,8 @@ func (h *Handler) diagnoseForwardRuntime(forward *forwardRecord) (map[string]int
 		return nil, errors.New("隧道配置不完整")
 	}
 
+	ipPreference := h.repo.GetTunnelIPPreference(forward.TunnelID)
+
 	inNodes, chainHops, outNodes := splitChainNodeGroups(chainRows)
 	results := make([]map[string]interface{}, 0, len(chainRows)*2+len(targets))
 	nodeCache := map[int64]*nodeRecord{}
@@ -383,7 +385,7 @@ func (h *Handler) diagnoseForwardRuntime(forward *forwardRecord) (map[string]int
 						"fromChainType": 1,
 						"toChainType":   2,
 						"toInx":         firstNode.Inx,
-					}, "")
+					}, ipPreference)
 				}
 			} else {
 				for _, outNode := range outNodes {
@@ -391,7 +393,7 @@ func (h *Handler) diagnoseForwardRuntime(forward *forwardRecord) (map[string]int
 					h.appendChainHopDiagnosis(&results, nodeCache, inNode.NodeID, outNode, description, map[string]interface{}{
 						"fromChainType": 1,
 						"toChainType":   3,
-					}, "")
+					}, ipPreference)
 				}
 			}
 		}
@@ -406,7 +408,7 @@ func (h *Handler) diagnoseForwardRuntime(forward *forwardRecord) (map[string]int
 							"fromInx":       currentNode.Inx,
 							"toChainType":   2,
 							"toInx":         nextNode.Inx,
-						}, "")
+						}, ipPreference)
 					}
 				} else {
 					for _, outNode := range outNodes {
@@ -415,7 +417,7 @@ func (h *Handler) diagnoseForwardRuntime(forward *forwardRecord) (map[string]int
 							"fromChainType": 2,
 							"fromInx":       currentNode.Inx,
 							"toChainType":   3,
-						}, "")
+						}, ipPreference)
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- propagate tunnel `ipPreference` into forward diagnosis chain-hop probing so v6-priority tunnels diagnose against IPv6 targets first
- keep existing compatibility fallback behavior in host selection while removing the unintended default-to-v4 path for forward diagnose
- add a contract test that verifies entry->chain and chain->exit forward diagnosis steps use IPv6 targets when tunnel preference is `v6`

## Validation
- `HOME=/root GOPATH=/root/go GOCACHE=/tmp/go-build go test ./internal/http/handler/...`
- `HOME=/root GOPATH=/root/go GOCACHE=/tmp/go-build go test ./tests/contract -run "TestDiagnosisChainCoverageContracts|TestForwardDiagnosisRespectsTunnelIPPreferenceContract"`