### PR TITLE
feat(node): add stable/test release channels for install and upgrade

### DIFF
--- a/go-backend/internal/http/handler/upgrade_release_channel_test.go
+++ b/go-backend/internal/http/handler/upgrade_release_channel_test.go
@@ -1,0 +1,46 @@
+package handler
+
+import "testing"
+
+func TestReleaseChannelFromTag(t *testing.T) {
+	tests := []struct {
+		name    string
+		tag     string
+		expects string
+	}{
+		{name: "stable semantic version", tag: "2.1.4", expects: releaseChannelStable},
+		{name: "v prefix should be dev", tag: "v2.1.4", expects: releaseChannelDev},
+		{name: "rc release", tag: "2.1.4-rc2", expects: releaseChannelDev},
+		{name: "beta release", tag: "2.1.4-beta.1", expects: releaseChannelDev},
+		{name: "alpha release", tag: "2.1.4-alpha", expects: releaseChannelDev},
+		{name: "non numeric tag", tag: "nightly", expects: releaseChannelDev},
+		{name: "empty tag", tag: "", expects: releaseChannelDev},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := releaseChannelFromTag(tc.tag); got != tc.expects {
+				t.Fatalf("releaseChannelFromTag(%q) = %q, want %q", tc.tag, got, tc.expects)
+			}
+		})
+	}
+}
+
+func TestNormalizeReleaseChannel(t *testing.T) {
+	tests := []struct {
+		input   string
+		expects string
+	}{
+		{input: "", expects: releaseChannelStable},
+		{input: "stable", expects: releaseChannelStable},
+		{input: "dev", expects: releaseChannelDev},
+		{input: "DEV", expects: releaseChannelDev},
+		{input: "preview", expects: releaseChannelStable},
+	}
+
+	for _, tc := range tests {
+		if got := normalizeReleaseChannel(tc.input); got != tc.expects {
+			t.Fatalf("normalizeReleaseChannel(%q) = %q, want %q", tc.input, got, tc.expects)
+		}
+	}
+}

--- a/vite-frontend/src/api/index.ts
+++ b/vite-frontend/src/api/index.ts
@@ -31,6 +31,8 @@ import axios from "axios";
 
 import Network from "./network";
 
+export type ReleaseChannel = "stable" | "dev";
+
 // 登陆相关接口
 export interface LoginData {
   username: string;
@@ -66,8 +68,10 @@ export const getNodeList = () => Network.post<NodeApiItem[]>("/node/list");
 export const updateNode = (data: NodeMutationPayload) =>
   Network.post("/node/update", data);
 export const deleteNode = (id: number) => Network.post("/node/delete", { id });
-export const getNodeInstallCommand = (id: number) =>
-  Network.post<string>("/node/install", { id });
+export const getNodeInstallCommand = (
+  id: number,
+  channel: ReleaseChannel = "stable",
+) => Network.post<string>("/node/install", { id, channel });
 export const updateNodeOrder = (data: {
   nodes: Array<{ id: number; inx: number }>;
 }) => Network.post("/node/update-order", data);
@@ -77,20 +81,28 @@ export const checkNodeStatus = (nodeId?: number) => {
   return Network.post("/node/check-status", params);
 };
 
-export const upgradeNode = (id: number, version?: string) =>
+export const upgradeNode = (
+  id: number,
+  version?: string,
+  channel: ReleaseChannel = "stable",
+) =>
   Network.post(
     "/node/upgrade",
-    { id, version: version || "" },
+    { id, version: version || "", channel },
     { timeout: 5 * 60 * 1000 },
   );
-export const batchUpgradeNodes = (ids: number[], version?: string) =>
+export const batchUpgradeNodes = (
+  ids: number[],
+  version?: string,
+  channel: ReleaseChannel = "stable",
+) =>
   Network.post(
     "/node/batch-upgrade",
-    { ids, version: version || "" },
+    { ids, version: version || "", channel },
     { timeout: 15 * 60 * 1000 },
   );
-export const getNodeReleases = () =>
-  Network.post<NodeReleaseApiItem[]>("/node/releases");
+export const getNodeReleases = (channel: ReleaseChannel = "stable") =>
+  Network.post<NodeReleaseApiItem[]>("/node/releases", { channel });
 export const rollbackNode = (id: number) =>
   Network.post("/node/rollback", { id });
 

--- a/vite-frontend/src/api/types.ts
+++ b/vite-frontend/src/api/types.ts
@@ -172,6 +172,7 @@ export interface NodeReleaseApiItem {
   name: string;
   publishedAt: string;
   prerelease: boolean;
+  channel: "stable" | "dev";
 }
 
 export interface UserPackageInfoApiData {


### PR DESCRIPTION
## Summary
- classify release tags by channel: pure numeric tags are treated as stable, while tags containing alpha/beta/rc (or other non-numeric formats) are treated as test releases
- add channel-aware backend APIs for install/upgrade/release listing and pin install commands to the selected tag via `VERSION=<tag>`
- update node page UI and API clients to let users pick stable vs test channel for install and upgrade workflows

## Verification
- `go test ./internal/http/handler/...`
- `npm run build`