### PR TITLE
feat(mcp): add FLVX MCP service for panel control

### DIFF
--- a/mcp-panel/README.md
+++ b/mcp-panel/README.md
@@ -1,0 +1,52 @@
+# FLVX MCP Service
+
+This directory hosts the standalone MCP service for full FLVX panel control.
+
+- Design plan: `docs/PLAN.md`
+- Planned entrypoint: `cmd/flvx-mcp/main.go`
+
+## Phase 1 (current)
+
+- MCP server skeleton based on `github.com/modelcontextprotocol/go-sdk`
+- Transports: `stdio` and `http` (`/mcp`)
+- Health endpoint: `/healthz` (configurable)
+- Implemented read-only tools:
+  - `node.list`
+  - `user.list`
+
+## Phase 2 (in progress)
+
+- Added tools:
+  - `auth.login`
+  - `auth.user_package`
+  - `tunnel.list`
+  - `forward.list`
+  - `forward.delete` (dangerous op)
+  - `forward.pause` (dangerous op)
+  - `forward.resume` (dangerous op)
+  - `user.delete` (dangerous op)
+  - `node.delete` (dangerous op)
+  - `tunnel.delete` (dangerous op)
+- Added dangerous operation guard:
+  - `MCP_CONFIRM_TOKEN` (fail-closed when unset)
+- Added idempotency protection for dangerous mutations:
+  - `idempotency_key` is required on all dangerous tools
+  - `MCP_IDEMPOTENCY_TTL_SECONDS` controls dedupe retention window
+- Added audit logging:
+  - `MCP_AUDIT_ENABLED` (default `true`)
+
+## Run
+
+```bash
+go build ./...
+```
+
+```bash
+# stdio mode (default)
+MCP_TRANSPORT=stdio PANEL_BASE_URL=http://127.0.0.1:6365 MCP_CONFIRM_TOKEN=change-me go run ./cmd/flvx-mcp
+```
+
+```bash
+# http mode
+MCP_TRANSPORT=http MCP_HTTP_ADDR=:8088 PANEL_BASE_URL=http://127.0.0.1:6365 MCP_CONFIRM_TOKEN=change-me go run ./cmd/flvx-mcp
+```

--- a/mcp-panel/cmd/flvx-mcp/main.go
+++ b/mcp-panel/cmd/flvx-mcp/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"mcp-panel/internal/audit"
+	"mcp-panel/internal/config"
+	"mcp-panel/internal/panelclient"
+	"mcp-panel/internal/policy"
+	"mcp-panel/internal/tools"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func main() {
+	cfg, err := config.FromEnv()
+	if err != nil {
+		log.Fatalf("invalid config: %v", err)
+	}
+
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    cfg.ServerName,
+		Version: cfg.ServerVersion,
+	}, nil)
+
+	panel := panelclient.New(cfg.PanelBaseURL)
+	confirmPolicy := policy.NewConfirmPolicy(cfg.ConfirmToken)
+	idempotencyStore := policy.NewIdempotencyStore(cfg.IdempotencyTTL)
+	auditLogger := audit.NewLogger(cfg.AuditEnabled)
+	tools.NewRegistry(panel, confirmPolicy, idempotencyStore, auditLogger).Register(server)
+
+	switch cfg.MCPTransport {
+	case "stdio":
+		runStdio(server)
+	case "http":
+		runHTTP(server, cfg)
+	}
+}
+
+func runStdio(server *mcp.Server) {
+	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
+		log.Fatalf("mcp stdio server exited: %v", err)
+	}
+}
+
+func runHTTP(server *mcp.Server, cfg config.Config) {
+	mcpHandler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+		return server
+	}, nil)
+
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", mcpHandler)
+	mux.HandleFunc(cfg.HealthPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	httpServer := &http.Server{
+		Addr:              cfg.HTTPAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		log.Printf("mcp http listening on %s", cfg.HTTPAddr)
+		errCh <- httpServer.ListenAndServe()
+	}()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case sig := <-sigCh:
+		log.Printf("received signal %s, shutting down", sig)
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("mcp http server failed: %v", err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := httpServer.Shutdown(ctx); err != nil {
+		log.Fatalf("mcp http shutdown failed: %v", err)
+	}
+}

--- a/mcp-panel/docs/PLAN.md
+++ b/mcp-panel/docs/PLAN.md
@@ -1,0 +1,230 @@
+# FLVX 面板全量控制 MCP 服务方案（第一版）
+
+## 1. 目标
+
+构建一个独立的 `mcp-panel/` 服务层，不改造现有 `go-backend` API 语义，在 MCP 协议下提供“面板可做的全部能力”，并在默认策略上做到可审计、可回滚、可分权。
+
+## 2. 现状约束（来自代码现状）
+
+- 后端主路由在 `go-backend/internal/http/handler/handler.go`，API 前缀以 `/api/v1/*` 为主。
+- 认证：面板端 JWT 走 `Authorization` 头，且为原始 token（非 `Bearer` 前缀）。
+- 返回包络：`{code, msg, data, ts}`，`code=0` 表示成功。
+- 大部分接口是 `POST`（包括 list 类接口），少数 `GET`（如公告、订阅）。
+- 权限：中间件按路径做管理员/普通用户分流（group/node/tunnel/speed-limit/backup 等默认管理员）。
+- 特殊通道：`/system-info` WebSocket、`/flow/*` 节点流量上报接口、federation 对接接口。
+
+## 3. 全量能力覆盖范围（MCP Tool Domain）
+
+按“面板功能域”进行工具命名空间拆分，确保覆盖当前可控能力：
+
+1. `auth.*`
+   - 登录、token 校验、用户上下文解析
+2. `user.*`
+   - 用户 CRUD、重置流量、改密、用户可见资源
+3. `node.*`
+   - 节点 CRUD、安装命令、检查状态、升级/批量升级/回滚、版本列表
+4. `tunnel.*`
+   - 隧道 CRUD、诊断、批量删除、批量重部署、顺序调整
+5. `forward.*`
+   - 转发 CRUD、强删、启停、诊断、批量删/启停/重部署/切换隧道
+6. `speed_limit.*`
+   - 限速策略 CRUD 与关联查询
+7. `group.*`
+   - 用户组/隧道组/权限组 CRUD、分配、撤销
+8. `config.*`
+   - 系统配置读取、批量更新、单项更新
+9. `backup.*`
+   - 导出、导入、恢复（含导入前自动备份信息）
+10. `announcement.*`
+   - 公告读取与更新
+11. `federation.*`
+   - share 管理、remote usage、connect/tunnel/runtime 指令、远端节点导入
+12. `openapi.*`
+   - 订阅信息导出能力
+13. `ops.*`
+   - 诊断聚合、健康检查、能力发现、路由映射输出（便于 agent 自省）
+
+## 4. MCP 服务架构
+
+```text
+LLM/Client
+   -> MCP Transport (stdio / streamable-http)
+   -> mcp-panel (tool router + policy engine + audit)
+   -> go-backend HTTP API
+   -> go-gost/ws side effects (由后端现有逻辑触发)
+```
+
+### 4.1 目录规划（已创建）
+
+```text
+mcp-panel/
+  README.md
+  docs/
+    PLAN.md
+  cmd/
+    flvx-mcp/
+  internal/
+  pkg/
+```
+
+### 4.2 关键模块设计
+
+- `internal/transport/`
+  - stdio 与 streamable-http 启动器
+- `internal/auth/`
+  - MCP 会话鉴权（可选 OAuth/JWT）
+  - 上游面板 token 透传/托管
+- `internal/panelclient/`
+  - 对 `go-backend` 的 typed client
+  - 统一处理 `{code,msg,data,ts}` 解包与错误映射
+- `internal/tools/`
+  - 按 domain 拆分工具注册：`tools/node.go`、`tools/tunnel.go`...
+- `internal/policy/`
+  - 危险操作二次确认、幂等键、并发限制、速率限制
+- `internal/audit/`
+  - 结构化审计日志（tool、参数摘要、操作者、结果、耗时）
+- `internal/tasks/`
+  - 长任务状态（批量操作、导入导出、批量升级）与进度查询
+
+## 5. 安全与控制策略（默认强约束）
+
+1. 最小权限
+   - 只暴露显式注册的工具；按角色过滤工具列表。
+2. 危险操作双阶段
+   - `preview_*`（预检） + `apply_*`（执行）
+   - 对 `delete/force-delete/import/rollback/batch-*` 强制 `confirm_token`。
+3. 幂等与重放保护
+   - 所有 mutation 工具接受 `idempotency_key`，服务端做时间窗去重。
+4. 审计
+   - 每次工具调用写审计日志，支持按用户/时间/工具检索。
+5. 限流与熔断
+   - 针对批量接口和 federation 接口设置更严流控，避免级联故障。
+
+## 6. 工具入参/出参统一约定
+
+- 入参统一结构：
+  - `auth_context`（可选）：token 引用或会话凭据
+  - `request`: 业务参数
+  - `idempotency_key`: mutation 必填
+- 出参统一结构：
+  - `ok: boolean`
+  - `panel_code / panel_msg`
+  - `data`
+  - `trace_id`
+
+> 说明：内部仍保留对面板原始 `{code,msg,data,ts}` 的完整映射，避免语义丢失。
+
+## 7. 分阶段落地计划
+
+### Phase 0（本轮）
+- 建立独立目录与方案文档
+- 梳理路由、认证、权限、响应约定
+
+### Phase 1（骨架）
+- 初始化 Go module、配置加载、健康检查
+- 接入 transport（先 stdio，后 streamable-http）
+- 实现 `panelclient` 基础能力
+
+### Phase 2（核心域）
+- `auth/user/node/tunnel/forward` 工具集
+- 危险操作二次确认
+- 审计日志
+
+### Phase 3（全量域）
+- `speed_limit/group/config/backup/announcement/federation/openapi/ops`
+- 长任务执行器与进度工具
+
+### Phase 4（硬化）
+- 权限矩阵、限流、熔断、压测、回归验证
+- 发布与运维文档
+
+## 8. 验收标准
+
+- 功能覆盖：`/api/v1` 可控能力在 MCP 层 1:1 或等价覆盖。
+- 安全覆盖：所有高风险工具需二次确认+审计。
+- 可观测性：每个工具调用具备 trace 与审计记录。
+- 一致性：错误语义与原面板 API 保持可追溯映射。
+
+## 9. 任务追踪（每完成一项就打标）
+
+- [x] 任务1：梳理现有面板能力边界（路由/鉴权/响应/模块）
+- [x] 任务2：并行外部调研（MCP 规范 + Go 实现生态）
+- [x] 任务3：创建独立 `mcp-panel/` 目录与基础结构
+- [x] 任务4：输出完整 Markdown 方案（本文件，后续可继续迭代）
+- [x] 任务5：进入实现阶段（Phase 1 骨架已启动并可构建）
+- [x] 任务6：推进 Phase 2 第一批核心工具（auth/tunnel/forward）
+- [x] 任务7：推进 Phase 2 第二批危险操作与幂等保护（delete/pause/resume）
+
+## 11. Phase 1 执行记录（本轮）
+
+- [x] 初始化 `mcp-panel/go.mod`，引入官方 `github.com/modelcontextprotocol/go-sdk`
+- [x] 新增配置模块：`internal/config/config.go`
+- [x] 新增面板客户端：`internal/panelclient/client.go`
+  - 已实现统一包络解析：`{code,msg,data,ts}`
+  - 已实现：`ListNodes`、`ListUsers`
+- [x] 新增工具注册：`internal/tools/tools.go`
+  - 已实现只读样板工具：`node.list`、`user.list`
+- [x] 新增入口：`cmd/flvx-mcp/main.go`
+  - 已支持 `stdio` 与 `http`（streamable-http）两种模式
+  - 已暴露健康检查端点（默认 `/healthz`）
+- [x] 已完成构建验证：`go build ./...`
+
+### 11.1 当前可用环境变量
+
+- `MCP_SERVER_NAME`（默认：`flvx-panel-mcp`）
+- `MCP_SERVER_VERSION`（默认：`0.1.0`）
+- `PANEL_BASE_URL`（默认：`http://127.0.0.1:6365`）
+- `MCP_TRANSPORT`（可选：`stdio`/`http`，默认：`stdio`）
+- `MCP_HTTP_ADDR`（默认：`:8088`）
+- `MCP_HEALTH_PATH`（默认：`/healthz`）
+- `MCP_CONFIRM_TOKEN`（危险操作确认令牌，未配置时危险操作默认禁用）
+- `MCP_AUDIT_ENABLED`（是否开启审计日志，默认：`true`）
+- `MCP_IDEMPOTENCY_TTL_SECONDS`（幂等结果缓存秒数，默认：`3600`）
+
+## 12. Phase 2 执行记录
+
+### 12.1 第一批
+
+- [x] 扩展 `panelclient`：
+  - `Login` -> `/api/v1/user/login`
+  - `UserPackage` -> `/api/v1/user/package`
+  - `ListTunnels` -> `/api/v1/tunnel/list`
+  - `ListForwards` -> `/api/v1/forward/list`
+  - `DeleteForward` -> `/api/v1/forward/delete`
+- [x] 新增 `internal/policy/confirm.go`
+  - 危险操作 `confirm_token` 校验（fail-closed）
+- [x] 新增 `internal/audit/logger.go`
+  - 工具调用结构化日志（tool、outcome、duration）
+- [x] 扩展 MCP tools：
+  - `auth.login`
+  - `auth.user_package`
+  - `tunnel.list`
+  - `forward.list`
+  - `forward.delete`（危险操作）
+- [x] 主程序装配 `policy + audit`，完成工具注册
+
+### 12.2 第二批（危险操作 + 幂等）
+
+- [x] 扩展 `panelclient`：
+  - `DeleteUser` -> `/api/v1/user/delete`
+  - `DeleteNode` -> `/api/v1/node/delete`
+  - `DeleteTunnel` -> `/api/v1/tunnel/delete`
+  - `PauseForward` -> `/api/v1/forward/pause`
+  - `ResumeForward` -> `/api/v1/forward/resume`
+- [x] 新增 `internal/policy/idempotency.go`
+  - `IdempotencyStore`（TTL、冲突检测、重放返回）
+- [x] 扩展危险操作工具并强制：
+  - `confirm_token`
+  - `idempotency_key`
+- [x] 新增危险操作 MCP tools：
+  - `user.delete`
+  - `node.delete`
+  - `tunnel.delete`
+  - `forward.pause`
+  - `forward.resume`
+  - `forward.delete`（升级为强制幂等）
+- [x] 主程序装配 `IdempotencyStore`，并接入配置 `MCP_IDEMPOTENCY_TTL_SECONDS`
+
+## 13. 下一步建议
+
+优先推进 Phase 2 第三批：补齐 `user.create/update`、`node.create/update`、`tunnel.create/update`，再补 `forward.create/update/batch-*`，并把 `idempotency_key` 扩展到所有 mutation 工具。

--- a/mcp-panel/go.mod
+++ b/mcp-panel/go.mod
@@ -1,0 +1,13 @@
+module mcp-panel
+
+go 1.24.0
+
+toolchain go1.24.4
+
+require github.com/modelcontextprotocol/go-sdk v1.3.0
+
+require (
+	github.com/google/jsonschema-go v0.4.2 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	golang.org/x/oauth2 v0.30.0 // indirect
+)

--- a/mcp-panel/go.sum
+++ b/mcp-panel/go.sum
@@ -1,0 +1,14 @@
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/modelcontextprotocol/go-sdk v1.3.0 h1:gMfZkv3DzQF5q/DcQePo5rahEY+sguyPfXDfNBcT0Zs=
+github.com/modelcontextprotocol/go-sdk v1.3.0/go.mod h1:AnQ//Qc6+4nIyyrB4cxBU7UW9VibK4iOZBeyP/rF1IE=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=

--- a/mcp-panel/internal/audit/logger.go
+++ b/mcp-panel/internal/audit/logger.go
@@ -1,0 +1,47 @@
+package audit
+
+import (
+	"encoding/json"
+	"log"
+	"time"
+)
+
+type ToolEvent struct {
+	TS         string `json:"ts"`
+	Tool       string `json:"tool"`
+	Outcome    string `json:"outcome"`
+	DurationMS int64  `json:"duration_ms"`
+	Message    string `json:"message,omitempty"`
+}
+
+type Logger struct {
+	enabled bool
+}
+
+func NewLogger(enabled bool) *Logger {
+	return &Logger{enabled: enabled}
+}
+
+func (l *Logger) LogToolCall(tool string, startedAt time.Time, err error) {
+	if l == nil || !l.enabled {
+		return
+	}
+
+	event := ToolEvent{
+		TS:         time.Now().UTC().Format(time.RFC3339Nano),
+		Tool:       tool,
+		Outcome:    "ok",
+		DurationMS: time.Since(startedAt).Milliseconds(),
+	}
+	if err != nil {
+		event.Outcome = "error"
+		event.Message = err.Error()
+	}
+
+	b, marshalErr := json.Marshal(event)
+	if marshalErr != nil {
+		log.Printf("audit marshal error: %v", marshalErr)
+		return
+	}
+	log.Printf("mcp_audit %s", string(b))
+}

--- a/mcp-panel/internal/config/config.go
+++ b/mcp-panel/internal/config/config.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	ServerName     string
+	ServerVersion  string
+	PanelBaseURL   string
+	MCPTransport   string
+	HTTPAddr       string
+	HealthPath     string
+	ConfirmToken   string
+	AuditEnabled   bool
+	IdempotencyTTL time.Duration
+}
+
+func FromEnv() (Config, error) {
+	cfg := Config{
+		ServerName:     getEnv("MCP_SERVER_NAME", "flvx-panel-mcp"),
+		ServerVersion:  getEnv("MCP_SERVER_VERSION", "0.1.0"),
+		PanelBaseURL:   strings.TrimRight(getEnv("PANEL_BASE_URL", "http://127.0.0.1:6365"), "/"),
+		MCPTransport:   strings.ToLower(getEnv("MCP_TRANSPORT", "stdio")),
+		HTTPAddr:       getEnv("MCP_HTTP_ADDR", ":8088"),
+		HealthPath:     getEnv("MCP_HEALTH_PATH", "/healthz"),
+		ConfirmToken:   getEnv("MCP_CONFIRM_TOKEN", ""),
+		AuditEnabled:   getBoolEnv("MCP_AUDIT_ENABLED", true),
+		IdempotencyTTL: getDurationFromSeconds("MCP_IDEMPOTENCY_TTL_SECONDS", 3600),
+	}
+
+	switch cfg.MCPTransport {
+	case "stdio", "http":
+	default:
+		return Config{}, fmt.Errorf("invalid MCP_TRANSPORT %q, expected stdio or http", cfg.MCPTransport)
+	}
+
+	return cfg, nil
+}
+
+func getDurationFromSeconds(key string, fallbackSeconds int) time.Duration {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return time.Duration(fallbackSeconds) * time.Second
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return time.Duration(fallbackSeconds) * time.Second
+	}
+	return time.Duration(n) * time.Second
+}
+
+func getEnv(key, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func getBoolEnv(key string, fallback bool) bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	if v == "" {
+		return fallback
+	}
+	switch v {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return fallback
+	}
+}

--- a/mcp-panel/internal/panelclient/client.go
+++ b/mcp-panel/internal/panelclient/client.go
@@ -1,0 +1,199 @@
+package panelclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+type Envelope struct {
+	Code int             `json:"code"`
+	Msg  string          `json:"msg"`
+	TS   int64           `json:"ts"`
+	Data json.RawMessage `json:"data,omitempty"`
+}
+
+type LoginResult struct {
+	Token                 string `json:"token"`
+	Name                  string `json:"name"`
+	RoleID                int64  `json:"role_id"`
+	RequirePasswordChange bool   `json:"requirePasswordChange"`
+}
+
+func New(baseURL string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		http: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+func (c *Client) ListNodes(ctx context.Context, token string) ([]map[string]any, error) {
+	var out []map[string]any
+	if err := c.post(ctx, token, "/api/v1/node/list", map[string]any{}, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) ListUsers(ctx context.Context, token string, keyword string) ([]map[string]any, error) {
+	var out []map[string]any
+	payload := map[string]any{
+		"current": 1,
+		"size":    10000,
+		"keyword": keyword,
+	}
+	if err := c.post(ctx, token, "/api/v1/user/list", payload, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) Login(ctx context.Context, username, password, captchaID string) (*LoginResult, error) {
+	var out LoginResult
+	payload := map[string]any{
+		"username":  username,
+		"password":  password,
+		"captchaId": captchaID,
+	}
+	if err := c.post(ctx, "", "/api/v1/user/login", payload, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) UserPackage(ctx context.Context, token string) (map[string]any, error) {
+	var out map[string]any
+	if err := c.post(ctx, token, "/api/v1/user/package", map[string]any{}, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) ListTunnels(ctx context.Context, token string) ([]map[string]any, error) {
+	var out []map[string]any
+	if err := c.post(ctx, token, "/api/v1/tunnel/list", map[string]any{}, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) ListForwards(ctx context.Context, token string) ([]map[string]any, error) {
+	var out []map[string]any
+	if err := c.post(ctx, token, "/api/v1/forward/list", map[string]any{}, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) DeleteForward(ctx context.Context, token string, id int64) error {
+	if err := c.postByID(ctx, token, "/api/v1/forward/delete", id); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) PauseForward(ctx context.Context, token string, id int64) error {
+	if err := c.postByID(ctx, token, "/api/v1/forward/pause", id); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) ResumeForward(ctx context.Context, token string, id int64) error {
+	if err := c.postByID(ctx, token, "/api/v1/forward/resume", id); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) DeleteUser(ctx context.Context, token string, id int64) error {
+	if err := c.postByID(ctx, token, "/api/v1/user/delete", id); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) DeleteNode(ctx context.Context, token string, id int64) error {
+	if err := c.postByID(ctx, token, "/api/v1/node/delete", id); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) DeleteTunnel(ctx context.Context, token string, id int64) error {
+	if err := c.postByID(ctx, token, "/api/v1/tunnel/delete", id); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) postByID(ctx context.Context, token, path string, id int64) error {
+	payload := map[string]any{"id": id}
+	if err := c.post(ctx, token, path, payload, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) post(ctx context.Context, token, path string, payload any, out any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if strings.TrimSpace(token) != "" {
+		req.Header.Set("Authorization", strings.TrimSpace(token))
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("call panel api: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("panel http status %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return fmt.Errorf("decode panel envelope: %w", err)
+	}
+	if env.Code != 0 {
+		return fmt.Errorf("panel error code=%d msg=%s", env.Code, env.Msg)
+	}
+
+	if len(env.Data) == 0 || string(env.Data) == "null" {
+		return nil
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(env.Data, out); err != nil {
+		return fmt.Errorf("decode panel data: %w", err)
+	}
+
+	return nil
+}

--- a/mcp-panel/internal/policy/confirm.go
+++ b/mcp-panel/internal/policy/confirm.go
@@ -1,0 +1,24 @@
+package policy
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ConfirmPolicy struct {
+	confirmToken string
+}
+
+func NewConfirmPolicy(confirmToken string) *ConfirmPolicy {
+	return &ConfirmPolicy{confirmToken: strings.TrimSpace(confirmToken)}
+}
+
+func (p *ConfirmPolicy) RequireDangerous(confirmToken string) error {
+	if p == nil || p.confirmToken == "" {
+		return fmt.Errorf("dangerous operation disabled: MCP_CONFIRM_TOKEN is not configured")
+	}
+	if strings.TrimSpace(confirmToken) != p.confirmToken {
+		return fmt.Errorf("confirm_token is invalid")
+	}
+	return nil
+}

--- a/mcp-panel/internal/policy/idempotency.go
+++ b/mcp-panel/internal/policy/idempotency.go
@@ -1,0 +1,77 @@
+package policy
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+type idempotencyEntry struct {
+	Fingerprint string
+	Response    []byte
+	ExpiresAt   time.Time
+}
+
+type IdempotencyStore struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	entries map[string]idempotencyEntry
+}
+
+func NewIdempotencyStore(ttl time.Duration) *IdempotencyStore {
+	if ttl <= 0 {
+		ttl = time.Hour
+	}
+	return &IdempotencyStore{
+		ttl:     ttl,
+		entries: make(map[string]idempotencyEntry),
+	}
+}
+
+func (s *IdempotencyStore) Lookup(toolName, idempotencyKey, fingerprint string) (response []byte, replay bool, conflict bool) {
+	if s == nil {
+		return nil, false, false
+	}
+	storageKey := toolName + "::" + idempotencyKey
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.entries[storageKey]
+	if !ok {
+		return nil, false, false
+	}
+	if now.After(entry.ExpiresAt) {
+		delete(s.entries, storageKey)
+		return nil, false, false
+	}
+	if entry.Fingerprint != fingerprint {
+		return nil, false, true
+	}
+	out := make([]byte, len(entry.Response))
+	copy(out, entry.Response)
+	return out, true, false
+}
+
+func (s *IdempotencyStore) Save(toolName, idempotencyKey, fingerprint string, response any) error {
+	if s == nil {
+		return nil
+	}
+	b, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+
+	storageKey := toolName + "::" + idempotencyKey
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.entries[storageKey] = idempotencyEntry{
+		Fingerprint: fingerprint,
+		Response:    b,
+		ExpiresAt:   time.Now().Add(s.ttl),
+	}
+	return nil
+}

--- a/mcp-panel/internal/tools/tools.go
+++ b/mcp-panel/internal/tools/tools.go
@@ -1,0 +1,343 @@
+package tools
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"mcp-panel/internal/audit"
+	"mcp-panel/internal/panelclient"
+	"mcp-panel/internal/policy"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type Registry struct {
+	panel       *panelclient.Client
+	confirm     *policy.ConfirmPolicy
+	idempotency *policy.IdempotencyStore
+	audit       *audit.Logger
+}
+
+func NewRegistry(panel *panelclient.Client, confirm *policy.ConfirmPolicy, idempotency *policy.IdempotencyStore, auditLogger *audit.Logger) *Registry {
+	return &Registry{panel: panel, confirm: confirm, idempotency: idempotency, audit: auditLogger}
+}
+
+func (r *Registry) Register(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "auth.login",
+		Description: "Login panel user and return JWT token from /api/v1/user/login",
+	}, r.authLogin)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "auth.user_package",
+		Description: "Get current user package from /api/v1/user/package",
+	}, r.authUserPackage)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "node.list",
+		Description: "List panel nodes via /api/v1/node/list",
+	}, r.nodeList)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "tunnel.list",
+		Description: "List panel tunnels via /api/v1/tunnel/list",
+	}, r.tunnelList)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "forward.list",
+		Description: "List panel forwards via /api/v1/forward/list",
+	}, r.forwardList)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "user.list",
+		Description: "List panel users via /api/v1/user/list",
+	}, r.userList)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "forward.delete",
+		Description: "Delete forward by id via /api/v1/forward/delete (requires confirm_token)",
+	}, r.forwardDelete)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "forward.pause",
+		Description: "Pause forward by id via /api/v1/forward/pause (requires confirm_token)",
+	}, r.forwardPause)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "forward.resume",
+		Description: "Resume forward by id via /api/v1/forward/resume (requires confirm_token)",
+	}, r.forwardResume)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "user.delete",
+		Description: "Delete user by id via /api/v1/user/delete (requires confirm_token)",
+	}, r.userDelete)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "node.delete",
+		Description: "Delete node by id via /api/v1/node/delete (requires confirm_token)",
+	}, r.nodeDelete)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "tunnel.delete",
+		Description: "Delete tunnel by id via /api/v1/tunnel/delete (requires confirm_token)",
+	}, r.tunnelDelete)
+}
+
+type CommonAuthInput struct {
+	PanelToken string `json:"panel_token" jsonschema:"Raw panel JWT token for Authorization header"`
+}
+
+type NodeListInput struct {
+	CommonAuthInput
+}
+
+type UserListInput struct {
+	CommonAuthInput
+	Keyword string `json:"keyword,omitempty" jsonschema:"Optional keyword for user filtering"`
+}
+
+type LoginInput struct {
+	Username  string `json:"username" jsonschema:"Panel username"`
+	Password  string `json:"password" jsonschema:"Panel password"`
+	CaptchaID string `json:"captcha_id,omitempty" jsonschema:"Optional captcha id"`
+}
+
+type LoginOutput struct {
+	Token                 string `json:"token"`
+	Name                  string `json:"name"`
+	RoleID                int64  `json:"role_id"`
+	RequirePasswordChange bool   `json:"requirePasswordChange"`
+}
+
+type UserPackageInput struct {
+	CommonAuthInput
+}
+
+type DataOutput struct {
+	Data map[string]any `json:"data"`
+}
+
+type ListOutput struct {
+	Items []map[string]any `json:"items" jsonschema:"List response items"`
+	Count int              `json:"count" jsonschema:"Total item count"`
+}
+
+type MutationByIDInput struct {
+	CommonAuthInput
+	ID             int64  `json:"id" jsonschema:"Resource ID"`
+	ConfirmToken   string `json:"confirm_token" jsonschema:"Confirm token required for dangerous operations"`
+	IdempotencyKey string `json:"idempotency_key" jsonschema:"Idempotency key for mutation replay protection"`
+}
+
+type MutationOutput struct {
+	ID       int64  `json:"id"`
+	Action   string `json:"action"`
+	Replayed bool   `json:"replayed"`
+}
+
+func (r *Registry) authLogin(ctx context.Context, _ *mcp.CallToolRequest, in LoginInput) (result *mcp.CallToolResult, out LoginOutput, err error) {
+	startedAt := time.Now()
+	defer func() { r.audit.LogToolCall("auth.login", startedAt, err) }()
+
+	if strings.TrimSpace(in.Username) == "" {
+		return nil, LoginOutput{}, fmt.Errorf("username is required")
+	}
+	if strings.TrimSpace(in.Password) == "" {
+		return nil, LoginOutput{}, fmt.Errorf("password is required")
+	}
+
+	login, err := r.panel.Login(ctx, in.Username, in.Password, in.CaptchaID)
+	if err != nil {
+		return nil, LoginOutput{}, err
+	}
+
+	out = LoginOutput{
+		Token:                 login.Token,
+		Name:                  login.Name,
+		RoleID:                login.RoleID,
+		RequirePasswordChange: login.RequirePasswordChange,
+	}
+	return textResult(out), out, nil
+}
+
+func (r *Registry) authUserPackage(ctx context.Context, _ *mcp.CallToolRequest, in UserPackageInput) (result *mcp.CallToolResult, out DataOutput, err error) {
+	startedAt := time.Now()
+	defer func() { r.audit.LogToolCall("auth.user_package", startedAt, err) }()
+
+	if strings.TrimSpace(in.PanelToken) == "" {
+		return nil, DataOutput{}, fmt.Errorf("panel_token is required")
+	}
+
+	pkg, err := r.panel.UserPackage(ctx, in.PanelToken)
+	if err != nil {
+		return nil, DataOutput{}, err
+	}
+	out = DataOutput{Data: pkg}
+	return textResult(out), out, nil
+}
+
+func (r *Registry) nodeList(ctx context.Context, _ *mcp.CallToolRequest, in NodeListInput) (result *mcp.CallToolResult, out ListOutput, err error) {
+	startedAt := time.Now()
+	defer func() { r.audit.LogToolCall("node.list", startedAt, err) }()
+
+	if strings.TrimSpace(in.PanelToken) == "" {
+		return nil, ListOutput{}, fmt.Errorf("panel_token is required")
+	}
+
+	items, err := r.panel.ListNodes(ctx, in.PanelToken)
+	if err != nil {
+		return nil, ListOutput{}, err
+	}
+	out = ListOutput{Items: items, Count: len(items)}
+	return textResult(out), out, nil
+}
+
+func (r *Registry) userList(ctx context.Context, _ *mcp.CallToolRequest, in UserListInput) (result *mcp.CallToolResult, out ListOutput, err error) {
+	startedAt := time.Now()
+	defer func() { r.audit.LogToolCall("user.list", startedAt, err) }()
+
+	if strings.TrimSpace(in.PanelToken) == "" {
+		return nil, ListOutput{}, fmt.Errorf("panel_token is required")
+	}
+
+	items, err := r.panel.ListUsers(ctx, in.PanelToken, in.Keyword)
+	if err != nil {
+		return nil, ListOutput{}, err
+	}
+	out = ListOutput{Items: items, Count: len(items)}
+	return textResult(out), out, nil
+}
+
+func (r *Registry) tunnelList(ctx context.Context, _ *mcp.CallToolRequest, in NodeListInput) (result *mcp.CallToolResult, out ListOutput, err error) {
+	startedAt := time.Now()
+	defer func() { r.audit.LogToolCall("tunnel.list", startedAt, err) }()
+
+	if strings.TrimSpace(in.PanelToken) == "" {
+		return nil, ListOutput{}, fmt.Errorf("panel_token is required")
+	}
+
+	items, err := r.panel.ListTunnels(ctx, in.PanelToken)
+	if err != nil {
+		return nil, ListOutput{}, err
+	}
+	out = ListOutput{Items: items, Count: len(items)}
+	return textResult(out), out, nil
+}
+
+func (r *Registry) forwardList(ctx context.Context, _ *mcp.CallToolRequest, in NodeListInput) (result *mcp.CallToolResult, out ListOutput, err error) {
+	startedAt := time.Now()
+	defer func() { r.audit.LogToolCall("forward.list", startedAt, err) }()
+
+	if strings.TrimSpace(in.PanelToken) == "" {
+		return nil, ListOutput{}, fmt.Errorf("panel_token is required")
+	}
+
+	items, err := r.panel.ListForwards(ctx, in.PanelToken)
+	if err != nil {
+		return nil, ListOutput{}, err
+	}
+	out = ListOutput{Items: items, Count: len(items)}
+	return textResult(out), out, nil
+}
+
+func (r *Registry) forwardDelete(ctx context.Context, _ *mcp.CallToolRequest, in MutationByIDInput) (result *mcp.CallToolResult, out MutationOutput, err error) {
+	return r.runDangerousMutation(ctx, "forward.delete", "forward_delete", in, func(ctx context.Context, token string, id int64) error {
+		return r.panel.DeleteForward(ctx, token, id)
+	})
+}
+
+func (r *Registry) forwardPause(ctx context.Context, _ *mcp.CallToolRequest, in MutationByIDInput) (result *mcp.CallToolResult, out MutationOutput, err error) {
+	return r.runDangerousMutation(ctx, "forward.pause", "forward_pause", in, func(ctx context.Context, token string, id int64) error {
+		return r.panel.PauseForward(ctx, token, id)
+	})
+}
+
+func (r *Registry) forwardResume(ctx context.Context, _ *mcp.CallToolRequest, in MutationByIDInput) (result *mcp.CallToolResult, out MutationOutput, err error) {
+	return r.runDangerousMutation(ctx, "forward.resume", "forward_resume", in, func(ctx context.Context, token string, id int64) error {
+		return r.panel.ResumeForward(ctx, token, id)
+	})
+}
+
+func (r *Registry) userDelete(ctx context.Context, _ *mcp.CallToolRequest, in MutationByIDInput) (result *mcp.CallToolResult, out MutationOutput, err error) {
+	return r.runDangerousMutation(ctx, "user.delete", "user_delete", in, func(ctx context.Context, token string, id int64) error {
+		return r.panel.DeleteUser(ctx, token, id)
+	})
+}
+
+func (r *Registry) nodeDelete(ctx context.Context, _ *mcp.CallToolRequest, in MutationByIDInput) (result *mcp.CallToolResult, out MutationOutput, err error) {
+	return r.runDangerousMutation(ctx, "node.delete", "node_delete", in, func(ctx context.Context, token string, id int64) error {
+		return r.panel.DeleteNode(ctx, token, id)
+	})
+}
+
+func (r *Registry) tunnelDelete(ctx context.Context, _ *mcp.CallToolRequest, in MutationByIDInput) (result *mcp.CallToolResult, out MutationOutput, err error) {
+	return r.runDangerousMutation(ctx, "tunnel.delete", "tunnel_delete", in, func(ctx context.Context, token string, id int64) error {
+		return r.panel.DeleteTunnel(ctx, token, id)
+	})
+}
+
+func (r *Registry) runDangerousMutation(
+	ctx context.Context,
+	toolName string,
+	action string,
+	in MutationByIDInput,
+	fn func(context.Context, string, int64) error,
+) (result *mcp.CallToolResult, out MutationOutput, err error) {
+	startedAt := time.Now()
+	defer func() { r.audit.LogToolCall(toolName, startedAt, err) }()
+
+	if strings.TrimSpace(in.PanelToken) == "" {
+		return nil, MutationOutput{}, fmt.Errorf("panel_token is required")
+	}
+	if in.ID <= 0 {
+		return nil, MutationOutput{}, fmt.Errorf("id must be greater than 0")
+	}
+	if strings.TrimSpace(in.IdempotencyKey) == "" {
+		return nil, MutationOutput{}, fmt.Errorf("idempotency_key is required")
+	}
+	if err := r.confirm.RequireDangerous(in.ConfirmToken); err != nil {
+		return nil, MutationOutput{}, err
+	}
+
+	fingerprint := mutationFingerprint(action, in.PanelToken, in.ID)
+	if data, replay, conflict := r.idempotency.Lookup(toolName, in.IdempotencyKey, fingerprint); conflict {
+		return nil, MutationOutput{}, fmt.Errorf("idempotency_key conflict: request payload mismatch")
+	} else if replay {
+		var replayOut MutationOutput
+		if err := json.Unmarshal(data, &replayOut); err != nil {
+			return nil, MutationOutput{}, fmt.Errorf("decode idempotent replay response: %w", err)
+		}
+		replayOut.Replayed = true
+		return textResult(replayOut), replayOut, nil
+	}
+
+	if err := fn(ctx, in.PanelToken, in.ID); err != nil {
+		return nil, MutationOutput{}, err
+	}
+	out = MutationOutput{ID: in.ID, Action: action, Replayed: false}
+	_ = r.idempotency.Save(toolName, in.IdempotencyKey, fingerprint, out)
+	return textResult(out), out, nil
+}
+
+func mutationFingerprint(action, panelToken string, id int64) string {
+	tokenHash := sha256.Sum256([]byte(strings.TrimSpace(panelToken)))
+	raw := fmt.Sprintf("%s|%d|%s", action, id, hex.EncodeToString(tokenHash[:]))
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+func textResult(v any) *mcp.CallToolResult {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "{}"}}}
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+	}
+}


### PR DESCRIPTION
## Summary

- 新增独立的 `mcp-panel/` MCP (Model Context Protocol) 服务，提供 FLVX 面板的全量控制能力
- 支持双传输模式：stdio 和 HTTP (streamable-http)
- 实现核心工具集：auth、user、node、tunnel、forward 域
- 危险操作强制二次确认 + 幂等保护 + 审计日志

## 功能详情

### MCP 服务骨架
- 基于 `github.com/modelcontextprotocol/go-sdk`
- 健康检查端点 `/healthz`
- 环境变量配置支持

### 已实现工具
- `auth.login`, `auth.user_package`
- `user.list`, `user.delete`
- `node.list`, `node.delete`
- `tunnel.list`, `tunnel.delete`
- `forward.list`, `forward.delete/pause/resume`

### 安全策略
- 危险操作需 `MCP_CONFIRM_TOKEN`（fail-closed）
- 所有 mutation 工具需 `idempotency_key`（防重放）
- 结构化审计日志（可配置 `MCP_AUDIT_ENABLED`）

## 运行方式

```bash
# stdio 模式
MCP_TRANSPORT=stdio PANEL_BASE_URL=http://127.0.0.1:6365 MCP_CONFIRM_TOKEN=change-me go run ./cmd/flvx-mcp

# http 模式
MCP_TRANSPORT=http MCP_HTTP_ADDR=:8088 PANEL_BASE_URL=http://127.0.0.1:6365 MCP_CONFIRM_TOKEN=change-me go run ./cmd/flvx-mcp
```