### PR TITLE
fix(frontend): prevent font blurriness caused by scale animations

### DIFF
--- a/vite-frontend/src/components/animated-page.tsx
+++ b/vite-frontend/src/components/animated-page.tsx
@@ -100,6 +100,7 @@ export const StaggerItem = ({
 
 /**
  * Simple fade-in animation for standalone elements (chips, badges, counters, etc.)
+ * Uses opacity + translateY to avoid font blurriness caused by scale transforms.
  */
 export const FadeIn = ({
     children,
@@ -111,9 +112,9 @@ export const FadeIn = ({
     className?: string;
 }) => (
     <motion.div
-        animate={{ opacity: 1, scale: 1 }}
+        animate={{ opacity: 1, y: 0 }}
         className={className}
-        initial={{ opacity: 0, scale: 0.95 }}
+        initial={{ opacity: 0, y: 8 }}
         transition={{ duration: 0.2, delay, ease: "easeOut" }}
     >
         {children}

--- a/vite-frontend/src/components/search-bar.tsx
+++ b/vite-frontend/src/components/search-bar.tsx
@@ -29,8 +29,8 @@ export function SearchBar({
                     <motion.div
                         key="search-btn"
                         animate={{ opacity: 1, scale: 1 }}
-                        exit={{ opacity: 0, scale: 0.8 }}
-                        initial={{ opacity: 0, scale: 0.8 }}
+                        exit={{ opacity: 0 }}
+                        initial={{ opacity: 0 }}
                         transition={{ duration: 0.12 }}
                     >
                         <Button

--- a/vite-frontend/src/layouts/admin.tsx
+++ b/vite-frontend/src/layouts/admin.tsx
@@ -346,7 +346,6 @@ export default function AdminLayout({
                       }
                      `}
                     transition={{ duration: 0.15 }}
-                    whileTap={{ scale: 0.97 }}
                     onClick={() => handleMenuClick(item.path)}
                   >
                     {isActive && (

--- a/vite-frontend/src/pages/index.tsx
+++ b/vite-frontend/src/pages/index.tsx
@@ -154,9 +154,9 @@ export default function IndexPage() {
     <DefaultLayout>
       <section className="flex flex-col items-center justify-center gap-4 py-4 sm:py-8 md:py-10 pb-20 min-h-[calc(100dvh-120px)] sm:min-h-[calc(100dvh-200px)]">
         <motion.div
-          animate={{ opacity: 1, y: 0, scale: 1 }}
+          animate={{ opacity: 1, y: 0 }}
           className="w-full max-w-md px-4 sm:px-0"
-          initial={{ opacity: 0, y: 24, scale: 0.97 }}
+          initial={{ opacity: 0, y: 24 }}
           transition={{ duration: 0.35, ease: [0.25, 0.46, 0.45, 0.94] }}
         >
           <Card className="w-full">

--- a/vite-frontend/src/styles/globals.css
+++ b/vite-frontend/src/styles/globals.css
@@ -2,6 +2,14 @@
 @import "tw-animate-css";
 @import "./tailwind-theme.pcss";
 
+/* GPU acceleration helper - prevents font blurriness during transforms */
+.gpu-accelerated {
+  will-change: transform;
+  backface-visibility: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 :root {
   --safe-area-top: env(safe-area-inset-top, 0px);
   --safe-area-bottom: env(safe-area-inset-bottom, 0px);
@@ -181,12 +189,12 @@ body {
 @keyframes captchaModalIn {
   from {
     opacity: 0;
-    transform: scale(0.9) translateY(-20px);
+    transform: translateY(-20px);
   }
 
   to {
     opacity: 1;
-    transform: scale(1) translateY(0);
+    transform: translateY(0);
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove `scale` transforms from Framer Motion animations that cause subpixel rendering issues on text elements
- Replace with `opacity + translateY` for smooth animations without blur
- Add `.gpu-accelerated` utility class for future use

## Root Cause
CSS `scale` animations trigger GPU subpixel rendering, causing text edges to appear blurry during and after animations.

## Changes

| File | Change |
|------|--------|
| `globals.css` | Remove `scale(0.9)` from captcha modal animation; add `.gpu-accelerated` utility |
| `animated-page.tsx` | `FadeIn`: change `scale: 0.95 → 1` to `y: 8 → 0` |
| `pages/index.tsx` | Login page: remove `scale: 0.97 → 1` |
| `search-bar.tsx` | Search button: remove exit/initial `scale: 0.8` |
| `layouts/admin.tsx` | Sidebar menu: remove `whileTap: { scale: 0.97 }` |

## Test Plan
- [x] Build succeeds (`npm run build`)
- [ ] Visual verification: check login page animation is smooth without blur
- [ ] Visual verification: check sidebar menu buttons no longer blur on tap
- [ ] Visual verification: check captcha modal animation is smooth

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>