### PR TITLE
fix(frontend): prevent font blur in sortable card components

### DIFF
--- a/vite-frontend/src/pages/forward.tsx
+++ b/vite-frontend/src/pages/forward.tsx
@@ -1175,11 +1175,14 @@ export default function ForwardPage() {
       isDragging,
     } = useSortable({ id: forward.id });
 
-    const style = {
+    const style: React.CSSProperties = {
       transform: transform ? CSS.Transform.toString(transform) : undefined,
       transition: isDragging ? undefined : transition || undefined,
       opacity: isDragging ? 0.5 : 1,
       willChange: "transform",
+      backfaceVisibility: "hidden",
+      WebkitFontSmoothing: "antialiased",
+      MozOsxFontSmoothing: "grayscale",
     };
 
     return (

--- a/vite-frontend/src/pages/node.tsx
+++ b/vite-frontend/src/pages/node.tsx
@@ -129,11 +129,14 @@ const SortableItem = ({
     isDragging,
   } = useSortable({ id });
 
-  const style = {
+  const style: React.CSSProperties = {
     transform: transform ? CSS.Transform.toString(transform) : undefined,
     transition: isDragging ? undefined : transition || undefined,
     opacity: isDragging ? 0.5 : 1,
     willChange: "transform",
+    backfaceVisibility: "hidden",
+    WebkitFontSmoothing: "antialiased",
+    MozOsxFontSmoothing: "grayscale",
   };
 
   return (

--- a/vite-frontend/src/pages/tunnel.tsx
+++ b/vite-frontend/src/pages/tunnel.tsx
@@ -666,11 +666,14 @@ export default function TunnelPage() {
       isDragging,
     } = useSortable({ id });
 
-    const style = {
+    const style: React.CSSProperties = {
       transform: transform ? CSS.Transform.toString(transform) : undefined,
       transition: isDragging ? undefined : transition || undefined,
       opacity: isDragging ? 0.5 : 1,
       willChange: "transform",
+      backfaceVisibility: "hidden",
+      WebkitFontSmoothing: "antialiased",
+      MozOsxFontSmoothing: "grayscale",
     };
 
     return (


### PR DESCRIPTION
## Summary
- Add `backface-visibility: hidden` and font-smoothing properties to SortableItem components to prevent GPU subpixel rendering blur during drag operations
- Fixes font blurriness on tunnel, forward, and node cards

## Root Cause
The `willChange: "transform"` in SortableItem triggers GPU composition during drag, causing subpixel rendering issues on text.

## Changes

| File | Change |
|------|--------|
| `tunnel.tsx` | Added `backfaceVisibility`, `WebkitFontSmoothing`, `MozOsxFontSmoothing` to SortableItem style |
| `forward.tsx` | Same fix for SortableCard wrapper |
| `node.tsx` | Same fix for SortableItem component |

## Test Plan
- [x] Build succeeds (`npm run build`)
- [ ] Visual verification: tunnel card text remains crisp during/after drag
- [ ] Visual verification: forward card text remains crisp during/after drag
- [ ] Visual verification: node card text remains crisp during/after drag

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>