### PR TITLE
fix(frontend): modal footer buttons visible on mobile

### DIFF
--- a/vite-frontend/src/shadcn-bridge/heroui/modal.tsx
+++ b/vite-frontend/src/shadcn-bridge/heroui/modal.tsx
@@ -207,7 +207,7 @@ export function ModalFooter({
   return (
     <div
       className={cn(
-        "mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        "mt-4 flex flex-wrap justify-end gap-2",
         context?.classNames?.footer,
         className,
       )}


### PR DESCRIPTION
## Summary
- 修复 ModalFooter 在移动端按钮显示问题
- 将 `flex-col-reverse` 改为 `flex-wrap justify-end`，确保"取消"和"创建"按钮在移动端都能正常显示

## 问题
在面板共享页面创建分享时，Modal 底部的按钮在移动端可能无法正常显示（由于 `flex-col-reverse` 导致顺序颠倒或被挤出视窗）。

## 解决方案
修改 ModalFooter 的 flex 布局为 `flex-wrap justify-end`，使按钮在移动端也能正确显示。