### PR TITLE
fix(frontend): enable content scroll on mobile

### DIFF
--- a/vite-frontend/src/layouts/admin.tsx
+++ b/vite-frontend/src/layouts/admin.tsx
@@ -533,7 +533,7 @@ export default function AdminLayout({
 
         {/* 主内容 */}
         <main
-          className={`flex-1 bg-gray-100 dark:bg-black overflow-hidden ${isMobile ? "" : "overflow-y-scroll"}`}
+          className="flex-1 bg-gray-100 dark:bg-black overflow-y-auto"
         >
           <AnimatePresence mode="wait">
             <motion.div


### PR DESCRIPTION
## Summary
- 修复移动端主内容区域无法滚动的问题
- 将 `overflow-hidden` 改为 `overflow-y-auto`，确保内容超出屏幕时可以滚动

## 问题
在移动端访问页面时，内容区域无法滚动，导致菜单显示不全，按钮点不到。

## 解决方案
修改 `admin.tsx` 中 main 元素的 overflow 属性，使其在移动端也能正常滚动。