### PR TITLE
fix(frontend): enable modal scroll on panel sharing page

### DIFF
--- a/vite-frontend/src/pages/panel-sharing.tsx
+++ b/vite-frontend/src/pages/panel-sharing.tsx
@@ -674,7 +674,7 @@ export default function PanelSharingPage() {
       </Tabs>
 
       {/* Create Share Modal */}
-      <Modal isOpen={createShareOpen} onClose={() => setCreateShareOpen(false)}>
+      <Modal isOpen={createShareOpen} onClose={() => setCreateShareOpen(false)} scrollBehavior="inside">
         <ModalContent>
           <ModalHeader>创建分享</ModalHeader>
           <ModalBody>
@@ -777,7 +777,7 @@ export default function PanelSharingPage() {
       </Modal>
 
       {/* Edit Share Modal */}
-      <Modal isOpen={editShareOpen} onClose={() => setEditShareOpen(false)}>
+      <Modal isOpen={editShareOpen} onClose={() => setEditShareOpen(false)} scrollBehavior="inside">
         <ModalContent>
           <ModalHeader>编辑分享</ModalHeader>
           <ModalBody>


### PR DESCRIPTION
## Summary
- 给"创建分享"和"编辑分享"弹窗添加 `scrollBehavior="inside"` 属性
- 修复移动端弹窗内容无法滚动的问题

## 问题
在移动端访问面板共享页面时，创建分享弹窗中的表单字段超出屏幕高度，无法滚动查看全部内容。

## 解决方案
为 Modal 组件添加 `scrollBehavior="inside"`，使 ModalBody 可以在内容超出时滚动。