### PR TITLE
fix(frontend): restore Android swipe for mobile batch toolbar

### DIFF
--- a/vite-frontend/src/pages/forward.tsx
+++ b/vite-frontend/src/pages/forward.tsx
@@ -1722,7 +1722,7 @@ export default function ForwardPage() {
             onOpen={() => setIsSearchVisible(true)}
           />
         </div>
-        <div className="flex min-h-9 min-w-0 max-w-full items-center justify-end gap-2 overflow-x-auto whitespace-nowrap [&>*]:shrink-0 sm:gap-3">
+        <div className="flex min-h-9 min-w-0 max-w-full items-center justify-start gap-2 overflow-x-auto whitespace-nowrap touch-pan-x sm:justify-end sm:gap-3 [&>*]:shrink-0">
           {selectMode ? (
             <>
               <span className="text-sm text-default-600 shrink-0">

--- a/vite-frontend/src/pages/node.tsx
+++ b/vite-frontend/src/pages/node.tsx
@@ -1075,7 +1075,7 @@ export default function NodePage() {
           />
         </div>
 
-        <div className="flex min-h-9 min-w-0 max-w-full items-center justify-end gap-2 overflow-x-auto whitespace-nowrap [&>*]:shrink-0">
+        <div className="flex min-h-9 min-w-0 max-w-full items-center justify-start gap-2 overflow-x-auto whitespace-nowrap touch-pan-x sm:justify-end [&>*]:shrink-0">
           {selectMode ? (
             <>
               <span className="text-sm text-default-600 shrink-0">

--- a/vite-frontend/src/pages/tunnel.tsx
+++ b/vite-frontend/src/pages/tunnel.tsx
@@ -710,7 +710,7 @@ export default function TunnelPage() {
           />
         </div>
 
-        <div className="flex min-h-9 min-w-0 max-w-full items-center justify-end gap-2 overflow-x-auto whitespace-nowrap [&>*]:shrink-0">
+        <div className="flex min-h-9 min-w-0 max-w-full items-center justify-start gap-2 overflow-x-auto whitespace-nowrap touch-pan-x sm:justify-end [&>*]:shrink-0">
           {selectMode ? (
             <>
               <span className="text-sm text-default-600 shrink-0">


### PR DESCRIPTION
## Summary
- fix mobile batch action toolbar in forward/node/tunnel pages to keep horizontal overflow reachable on Android
- switch toolbar alignment to start on mobile and keep right alignment on `sm+` to avoid `justify-end` overflow reachability issues
- add `touch-pan-x` to improve horizontal swipe handling on mobile browsers while preserving existing desktop layout

## Verification
- `npm run build` *(fails due to pre-existing issue: `src/main.tsx` cannot find module `virtual:pwa-register`)*
- `npm run lint` *(fails due to pre-existing a11y errors in unrelated files and in existing forward labels)*