### PR TITLE
feat: complete TUN tunnel implementation with topology validation and diagnostics

### DIFF
--- a/go-backend/internal/http/handler/control_plane.go
+++ b/go-backend/internal/http/handler/control_plane.go
@@ -757,94 +757,12 @@ func (h *Handler) prepareForwardDiagnosis(forward *forwardRecord) (string, []dia
 			}
 		}
 	case 2:
-		for _, inNode := range inNodes {
-			if len(chainHops) > 0 {
-				for _, firstNode := range chainHops[0] {
-					description := fmt.Sprintf("入口(%s)->第1跳(%s)", inNode.NodeName, firstNode.NodeName)
-					workItems = append(workItems, diagnosisWorkItem{
-						fromNodeID:   inNode.NodeID,
-						toNode:       firstNode,
-						hasChainHop:  true,
-						ipPreference: ipPreference,
-						description:  description,
-						metadata: map[string]interface{}{
-							"fromChainType": 1,
-							"toChainType":   2,
-							"toInx":         firstNode.Inx,
-						},
-					})
-				}
-			} else {
-				for _, outNode := range outNodes {
-					description := fmt.Sprintf("入口(%s)->出口(%s)", inNode.NodeName, outNode.NodeName)
-					workItems = append(workItems, diagnosisWorkItem{
-						fromNodeID:   inNode.NodeID,
-						toNode:       outNode,
-						hasChainHop:  true,
-						ipPreference: ipPreference,
-						description:  description,
-						metadata: map[string]interface{}{
-							"fromChainType": 1,
-							"toChainType":   3,
-						},
-					})
-				}
-			}
+		workItems = append(workItems, buildChainRuntimeDiagnosisWorkItems(inNodes, chainHops, outNodes, ipPreference, targets)...)
+	case 3:
+		if err := validateType3TunnelTopology(inNodes, outNodes); err != nil {
+			return "", nil, err
 		}
-
-		for i, hop := range chainHops {
-			for _, currentNode := range hop {
-				if i+1 < len(chainHops) {
-					for _, nextNode := range chainHops[i+1] {
-						description := fmt.Sprintf("第%d跳(%s)->第%d跳(%s)", i+1, currentNode.NodeName, i+2, nextNode.NodeName)
-						workItems = append(workItems, diagnosisWorkItem{
-							fromNodeID:   currentNode.NodeID,
-							toNode:       nextNode,
-							hasChainHop:  true,
-							ipPreference: ipPreference,
-							description:  description,
-							metadata: map[string]interface{}{
-								"fromChainType": 2,
-								"fromInx":       currentNode.Inx,
-								"toChainType":   2,
-								"toInx":         nextNode.Inx,
-							},
-						})
-					}
-				} else {
-					for _, outNode := range outNodes {
-						description := fmt.Sprintf("第%d跳(%s)->出口(%s)", i+1, currentNode.NodeName, outNode.NodeName)
-						workItems = append(workItems, diagnosisWorkItem{
-							fromNodeID:   currentNode.NodeID,
-							toNode:       outNode,
-							hasChainHop:  true,
-							ipPreference: ipPreference,
-							description:  description,
-							metadata: map[string]interface{}{
-								"fromChainType": 2,
-								"fromInx":       currentNode.Inx,
-								"toChainType":   3,
-							},
-						})
-					}
-				}
-			}
-		}
-
-		for _, outNode := range outNodes {
-			for _, target := range targets {
-				description := fmt.Sprintf("出口(%s)->目标(%s)", outNode.NodeName, target.Address)
-				workItems = append(workItems, diagnosisWorkItem{
-					fromNodeID:  outNode.NodeID,
-					targetIP:    target.IP,
-					targetPort:  target.Port,
-					description: description,
-					metadata: map[string]interface{}{
-						"fromChainType": 3,
-					},
-				})
-			}
-		}
+		workItems = append(workItems, buildChainRuntimeDiagnosisWorkItems(inNodes, chainHops, outNodes, ipPreference, targets)...)
 	default:
 		for _, inNode := range inNodes {
 			for _, target := range targets {
@@ -863,6 +781,110 @@ func (h *Handler) prepareForwardDiagnosis(forward *forwardRecord) (string, []dia
 	}
 
 	return forward.Name, workItems, nil
+}
+
+func buildChainRuntimeDiagnosisWorkItems(inNodes []chainNodeRecord, chainHops [][]chainNodeRecord, outNodes []chainNodeRecord, ipPreference string, targets []diagnosisTarget) []diagnosisWorkItem {
+	workItems := make([]diagnosisWorkItem, 0, len(inNodes)+len(outNodes)+len(chainHops)*2)
+	for _, inNode := range inNodes {
+		if len(chainHops) > 0 {
+			for _, firstNode := range chainHops[0] {
+				description := fmt.Sprintf("入口(%s)->第1跳(%s)", inNode.NodeName, firstNode.NodeName)
+				workItems = append(workItems, diagnosisWorkItem{
+					fromNodeID:   inNode.NodeID,
+					toNode:       firstNode,
+					hasChainHop:  true,
+					ipPreference: ipPreference,
+					description:  description,
+					metadata: map[string]interface{}{
+						"fromChainType": 1,
+						"toChainType":   2,
+						"toInx":         firstNode.Inx,
+					},
+				})
+			}
+		} else {
+			for _, outNode := range outNodes {
+				description := fmt.Sprintf("入口(%s)->出口(%s)", inNode.NodeName, outNode.NodeName)
+				workItems = append(workItems, diagnosisWorkItem{
+					fromNodeID:   inNode.NodeID,
+					toNode:       outNode,
+					hasChainHop:  true,
+					ipPreference: ipPreference,
+					description:  description,
+					metadata: map[string]interface{}{
+						"fromChainType": 1,
+						"toChainType":   3,
+					},
+				})
+			}
+		}
+	}
+
+	for i, hop := range chainHops {
+		for _, currentNode := range hop {
+			if i+1 < len(chainHops) {
+				for _, nextNode := range chainHops[i+1] {
+					description := fmt.Sprintf("第%d跳(%s)->第%d跳(%s)", i+1, currentNode.NodeName, i+2, nextNode.NodeName)
+					workItems = append(workItems, diagnosisWorkItem{
+						fromNodeID:   currentNode.NodeID,
+						toNode:       nextNode,
+						hasChainHop:  true,
+						ipPreference: ipPreference,
+						description:  description,
+						metadata: map[string]interface{}{
+							"fromChainType": 2,
+							"fromInx":       currentNode.Inx,
+							"toChainType":   2,
+							"toInx":         nextNode.Inx,
+						},
+					})
+				}
+			} else {
+				for _, outNode := range outNodes {
+					description := fmt.Sprintf("第%d跳(%s)->出口(%s)", i+1, currentNode.NodeName, outNode.NodeName)
+					workItems = append(workItems, diagnosisWorkItem{
+						fromNodeID:   currentNode.NodeID,
+						toNode:       outNode,
+						hasChainHop:  true,
+						ipPreference: ipPreference,
+						description:  description,
+						metadata: map[string]interface{}{
+							"fromChainType": 2,
+							"fromInx":       currentNode.Inx,
+							"toChainType":   3,
+						},
+					})
+				}
+			}
+		}
+	}
+
+	for _, outNode := range outNodes {
+		for _, target := range targets {
+			description := fmt.Sprintf("出口(%s)->目标(%s)", outNode.NodeName, target.Address)
+			workItems = append(workItems, diagnosisWorkItem{
+				fromNodeID:  outNode.NodeID,
+				targetIP:    target.IP,
+				targetPort:  target.Port,
+				description: description,
+				metadata: map[string]interface{}{
+					"fromChainType": 3,
+				},
+			})
+		}
+	}
+
+	return workItems
+}
+
+func validateType3TunnelTopology(inNodes []chainNodeRecord, outNodes []chainNodeRecord) error {
+	if len(inNodes) != 1 {
+		return fmt.Errorf("TUN隧道拓扑非法：仅允许单入口，当前 %d 个", len(inNodes))
+	}
+	if len(outNodes) != 1 {
+		return fmt.Errorf("TUN隧道拓扑非法：仅允许单出口，当前 %d 个", len(outNodes))
+	}
+	return nil
 }
 
 func (h *Handler) diagnoseTunnelRuntime(ctx context.Context, tunnelID int64) (map[string]interface{}, error) {
@@ -926,92 +948,14 @@ func (h *Handler) prepareTunnelDiagnosis(tunnelID int64) (string, string, []diag
 			})
 		}
 	case 2:
-		for _, inNode := range inNodes {
-			if len(chainHops) > 0 {
-				for _, firstNode := range chainHops[0] {
-					description := fmt.Sprintf("入口(%s)->第1跳(%s)", inNode.NodeName, firstNode.NodeName)
-					workItems = append(workItems, diagnosisWorkItem{
-						fromNodeID:   inNode.NodeID,
-						toNode:       firstNode,
-						hasChainHop:  true,
-						ipPreference: ipPreference,
-						description:  description,
-						metadata: map[string]interface{}{
-							"fromChainType": 1,
-							"toChainType":   2,
-							"toInx":         firstNode.Inx,
-						},
-					})
-				}
-			} else {
-				for _, outNode := range outNodes {
-					description := fmt.Sprintf("入口(%s)->出口(%s)", inNode.NodeName, outNode.NodeName)
-					workItems = append(workItems, diagnosisWorkItem{
-						fromNodeID:   inNode.NodeID,
-						toNode:       outNode,
-						hasChainHop:  true,
-						ipPreference: ipPreference,
-						description:  description,
-						metadata: map[string]interface{}{
-							"fromChainType": 1,
-							"toChainType":   3,
-						},
-					})
-				}
-			}
+		defaultTargets := []diagnosisTarget{{Address: "外网", IP: "www.bing.com", Port: 443}}
+		workItems = append(workItems, buildChainRuntimeDiagnosisWorkItems(inNodes, chainHops, outNodes, ipPreference, defaultTargets)...)
+	case 3:
+		if err := validateType3TunnelTopology(inNodes, outNodes); err != nil {
+			return "", "", nil, err
 		}
-
-		for i, hop := range chainHops {
-			for _, currentNode := range hop {
-				if i+1 < len(chainHops) {
-					for _, nextNode := range chainHops[i+1] {
-						description := fmt.Sprintf("第%d跳(%s)->第%d跳(%s)", i+1, currentNode.NodeName, i+2, nextNode.NodeName)
-						workItems = append(workItems, diagnosisWorkItem{
-							fromNodeID:   currentNode.NodeID,
-							toNode:       nextNode,
-							hasChainHop:  true,
-							ipPreference: ipPreference,
-							description:  description,
-							metadata: map[string]interface{}{
-								"fromChainType": 2,
-								"fromInx":       currentNode.Inx,
-								"toChainType":   2,
-								"toInx":         nextNode.Inx,
-							},
-						})
-					}
-				} else {
-					for _, outNode := range outNodes {
-						description := fmt.Sprintf("第%d跳(%s)->出口(%s)", i+1, currentNode.NodeName, outNode.NodeName)
-						workItems = append(workItems, diagnosisWorkItem{
-							fromNodeID:   currentNode.NodeID,
-							toNode:       outNode,
-							hasChainHop:  true,
-							ipPreference: ipPreference,
-							description:  description,
-							metadata: map[string]interface{}{
-								"fromChainType": 2,
-								"fromInx":       currentNode.Inx,
-								"toChainType":   3,
-							},
-						})
-					}
-				}
-			}
-		}
-
-		for _, outNode := range outNodes {
-			description := fmt.Sprintf("出口(%s)->外网", outNode.NodeName)
-			workItems = append(workItems, diagnosisWorkItem{
-				fromNodeID:  outNode.NodeID,
-				targetIP:    "www.bing.com",
-				targetPort:  443,
-				description: description,
-				metadata: map[string]interface{}{
-					"fromChainType": 3,
-				},
-			})
-		}
+		defaultTargets := []diagnosisTarget{{Address: "外网", IP: "www.bing.com", Port: 443}}
+		workItems = append(workItems, buildChainRuntimeDiagnosisWorkItems(inNodes, chainHops, outNodes, ipPreference, defaultTargets)...)
 	default:
 		for _, inNode := range inNodes {
 			description := fmt.Sprintf("入口(%s)->外网", inNode.NodeName)
@@ -1644,7 +1588,7 @@ func buildForwardServiceConfigs(baseName string, forward *forwardRecord, tunnel 
 			}
 			service["listener"].(map[string]interface{})["metadata"] = listenerMetadata
 		}
-		if tunnel != nil && tunnel.Type == 2 {
+		if tunnel != nil && (tunnel.Type == 2 || tunnel.Type == 3) {
 			service["handler"].(map[string]interface{})["chain"] = fmt.Sprintf("chains_%d", forward.TunnelID)
 		}
 		if tunnel != nil && tunnel.Type == 1 && strings.TrimSpace(node.InterfaceName) != "" {

--- a/go-backend/internal/http/handler/federation_runtime_test.go
+++ b/go-backend/internal/http/handler/federation_runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,6 +109,86 @@ func TestApplyTunnelRuntimeSkipsRemoteChainAndOutNodes(t *testing.T) {
 	}
 	if len(services) != 0 {
 		t.Fatalf("expected no local services for remote-only nodes, got %d", len(services))
+	}
+}
+
+func TestBuildTunnelTunServiceConfigUsesTunHandlerAndListener(t *testing.T) {
+	node := &nodeRecord{TCPListenAddr: "[::]", UDPListenAddr: "[::]"}
+	inNode := tunnelRuntimeNode{NodeID: 1, ChainType: 1, Port: 30001}
+	tunCfg := map[string]interface{}{"net": "10.0.0.1/24", "name": "demo0", "mtu": 1380}
+
+	services := buildTunnelTunServiceConfig(99, inNode, node, tunCfg)
+	if len(services) != 1 {
+		t.Fatalf("expected one service, got %d", len(services))
+	}
+	svc := services[0]
+
+	h, ok := svc["handler"].(map[string]interface{})
+	if !ok || asString(h["type"]) != "tun" {
+		t.Fatalf("expected handler.type=tun, got %#v", svc["handler"])
+	}
+	if asString(h["chain"]) != "chains_99" {
+		t.Fatalf("expected handler.chain=chains_99, got %v", h["chain"])
+	}
+
+	l, ok := svc["listener"].(map[string]interface{})
+	if !ok || asString(l["type"]) != "tun" {
+		t.Fatalf("expected listener.type=tun, got %#v", svc["listener"])
+	}
+
+	lm, ok := l["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected listener metadata")
+	}
+	if _, ok := lm["tunConfig"]; !ok {
+		t.Fatalf("expected listener metadata to include tunConfig")
+	}
+}
+
+func TestPrepareTunnelCreateStateType3RequiresSingleEntryAndExit(t *testing.T) {
+	r, err := repo.Open(filepath.Join(t.TempDir(), "panel.db"))
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer r.Close()
+
+	h := &Handler{repo: r}
+	now := time.Now().UnixMilli()
+
+	insertNode := func(name, ip, portRange string) int64 {
+		if execErr := r.DB().Exec(`
+			INSERT INTO node(name, secret, server_ip, server_ip_v4, server_ip_v6, port, interface_name, version, http, tls, socks, created_time, updated_time, status, tcp_listen_addr, udp_listen_addr, inx, is_remote, remote_url, remote_token, remote_config)
+			VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, name, name+"-secret", ip, ip, "", portRange, "", "v1", 1, 1, 1, now, now, 1, "[::]", "[::]", 0, 0, "", "", "").Error; execErr != nil {
+			t.Fatalf("insert node %s: %v", name, execErr)
+		}
+		return mustLastInsertID(t, r, name)
+	}
+
+	entry1 := insertNode("entry-1", "10.9.0.1", "30000-30010")
+	entry2 := insertNode("entry-2", "10.9.0.2", "30100-30110")
+	exit1 := insertNode("exit-1", "10.9.0.3", "30200-30210")
+
+	tx := r.DB().Begin()
+	if tx.Error != nil {
+		t.Fatalf("begin tx: %v", tx.Error)
+	}
+	defer tx.Rollback()
+
+	req := map[string]interface{}{
+		"name": "tun-topo-check",
+		"inNodeId": []interface{}{
+			map[string]interface{}{"nodeId": float64(entry1), "protocol": "tls", "strategy": "round"},
+			map[string]interface{}{"nodeId": float64(entry2), "protocol": "tls", "strategy": "round"},
+		},
+		"chainNodes": []interface{}{},
+		"outNodeId": []interface{}{
+			map[string]interface{}{"nodeId": float64(exit1), "protocol": "tls", "strategy": "round"},
+		},
+	}
+
+	if _, err := h.prepareTunnelCreateState(tx, req, 3, 0); err == nil || !strings.Contains(err.Error(), "仅允许单入口") {
+		t.Fatalf("expected single-entry topology error, got %v", err)
 	}
 }
 

--- a/go-backend/internal/http/handler/mutations.go
+++ b/go-backend/internal/http/handler/mutations.go
@@ -479,6 +479,10 @@ func (h *Handler) tunnelCreate(w http.ResponseWriter, r *http.Request) {
 	trafficRatio := asFloat(req["trafficRatio"], 1.0)
 	inIP := asString(req["inIp"])
 	ipPreference := asString(req["ipPreference"])
+	tunConfig := strings.TrimSpace(asString(req["tunConfig"]))
+	if typeVal != 3 {
+		tunConfig = ""
+	}
 	now := time.Now().UnixMilli()
 	inx := h.repo.NextIndex("tunnel")
 	localDomain := h.federationLocalDomain()
@@ -556,6 +560,7 @@ func (h *Handler) tunnelCreate(w http.ResponseWriter, r *http.Request) {
 		Name:         name,
 		TrafficRatio: trafficRatio,
 		Type:         typeVal,
+		TunConfig:    sql.NullString{String: tunConfig, Valid: tunConfig != ""},
 		Protocol:     "tls",
 		Flow:         flow,
 		CreatedTime:  now,
@@ -594,7 +599,7 @@ func (h *Handler) tunnelCreate(w http.ResponseWriter, r *http.Request) {
 		response.WriteJSON(w, response.Err(-2, err.Error()))
 		return
 	}
-	if typeVal == 2 {
+	if typeVal == 2 || typeVal == 3 {
 		createdChains, createdServices, applyErr := h.applyTunnelRuntime(runtimeState)
 		if applyErr != nil {
 			h.rollbackTunnelRuntime(createdChains, createdServices, tunnelID)
@@ -609,7 +614,7 @@ func (h *Handler) tunnelCreate(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) cleanupTunnelRuntime(tunnelID int64) {
 	tunnel, err := h.getTunnelRecord(tunnelID)
-	if err != nil || tunnel.Type != 2 {
+	if err != nil || (tunnel.Type != 2 && tunnel.Type != 3) {
 		return
 	}
 	chainRows, err := h.listChainNodesForTunnel(tunnelID)
@@ -623,6 +628,9 @@ func (h *Handler) cleanupTunnelRuntime(tunnelID int64) {
 	for _, row := range chainRows {
 		if row.ChainType == 1 {
 			_, _ = h.sendNodeCommand(row.NodeID, "DeleteChains", map[string]interface{}{"chain": chainName}, false, true)
+			if tunnel.Type == 3 {
+				_, _ = h.sendNodeCommand(row.NodeID, "DeleteService", map[string]interface{}{"services": []string{serviceName}}, false, true)
+			}
 		} else if row.ChainType == 2 {
 			_, _ = h.sendNodeCommand(row.NodeID, "DeleteChains", map[string]interface{}{"chain": chainName}, false, true)
 			_, _ = h.sendNodeCommand(row.NodeID, "DeleteService", map[string]interface{}{"services": []string{serviceName}}, false, true)
@@ -681,6 +689,10 @@ func (h *Handler) tunnelUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ipPreference := asString(req["ipPreference"])
+	tunConfig := strings.TrimSpace(asString(req["tunConfig"]))
+	if typeVal != 3 {
+		tunConfig = ""
+	}
 	localDomain := h.federationLocalDomain()
 
 	tx := h.repo.BeginTx()
@@ -719,6 +731,7 @@ func (h *Handler) tunnelUpdate(w http.ResponseWriter, r *http.Request) {
 		asInt(req["status"], 1),
 		inIp,
 		ipPreference,
+		tunConfig,
 		now,
 	); err != nil {
 		response.WriteJSON(w, response.Err(-2, err.Error()))
@@ -745,7 +758,7 @@ func (h *Handler) tunnelUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if typeVal == 2 {
+	if typeVal == 2 || typeVal == 3 {
 		createdChains, createdServices, applyErr := h.applyTunnelRuntime(runtimeState)
 		if applyErr != nil {
 			h.rollbackTunnelRuntime(createdChains, createdServices, id)
@@ -867,6 +880,7 @@ func (h *Handler) reconstructTunnelState(tunnelID int64) (*tunnelCreateState, er
 		TunnelID:     tunnelID,
 		Type:         tunnel.Type,
 		IPPreference: ipPreference,
+		TunConfig:    map[string]interface{}{},
 		InNodes:      make([]tunnelRuntimeNode, 0),
 		ChainHops:    make([][]tunnelRuntimeNode, 0),
 		OutNodes:     make([]tunnelRuntimeNode, 0),
@@ -882,6 +896,7 @@ func (h *Handler) reconstructTunnelState(tunnelID int64) (*tunnelCreateState, er
 			Protocol:  r.Protocol,
 			Strategy:  r.Strategy,
 			ChainType: 1,
+			Port:      r.Port,
 		})
 		state.NodeIDList = append(state.NodeIDList, r.NodeID)
 	}
@@ -935,7 +950,7 @@ func (h *Handler) redeployTunnelAndForwards(tunnelID int64) error {
 		return err
 	}
 
-	if tunnel.Type == 2 {
+	if tunnel.Type == 2 || tunnel.Type == 3 {
 		h.cleanupTunnelRuntime(tunnelID)
 		h.cleanupFederationRuntime(tunnelID)
 		state, err := h.reconstructTunnelState(tunnelID)
@@ -1993,6 +2008,7 @@ type tunnelCreateState struct {
 	TunnelID     int64
 	Type         int
 	IPPreference string // "" = auto, "v4" = prefer IPv4, "v6" = prefer IPv6
+	TunConfig    map[string]interface{}
 	InNodes      []tunnelRuntimeNode
 	ChainHops    [][]tunnelRuntimeNode
 	OutNodes     []tunnelRuntimeNode
@@ -2003,17 +2019,34 @@ type tunnelCreateState struct {
 func (h *Handler) prepareTunnelCreateState(tx *gorm.DB, req map[string]interface{}, tunnelType int, excludeTunnelID int64) (*tunnelCreateState, error) {
 	state := &tunnelCreateState{
 		Type:      tunnelType,
+		TunConfig: normalizeTunnelTunConfig(req["tunConfig"]),
 		InNodes:   make([]tunnelRuntimeNode, 0),
 		ChainHops: make([][]tunnelRuntimeNode, 0),
 		OutNodes:  make([]tunnelRuntimeNode, 0),
 		Nodes:     make(map[int64]*nodeRecord),
 	}
 	nodeIDs := make([]int64, 0)
+	allocated := map[int64]int{}
 
 	for _, item := range asMapSlice(req["inNodeId"]) {
 		nodeID := asInt64(item["nodeId"], 0)
 		if nodeID <= 0 {
 			continue
+		}
+		port := asInt(item["port"], 0)
+		if tunnelType == 3 && port <= 0 {
+			isRemote, remoteErr := h.repo.IsRemoteNodeTx(tx, nodeID)
+			if remoteErr != nil {
+				return nil, remoteErr
+			}
+			if isRemote {
+				return nil, errors.New("TUN入口节点端口不能为空")
+			}
+			var pickErr error
+			port, pickErr = h.repo.PickNodePortTx(tx, nodeID, allocated, excludeTunnelID)
+			if pickErr != nil {
+				return nil, pickErr
+			}
 		}
 		nodeIDs = append(nodeIDs, nodeID)
 		state.InNodes = append(state.InNodes, tunnelRuntimeNode{
@@ -2021,19 +2054,19 @@ func (h *Handler) prepareTunnelCreateState(tx *gorm.DB, req map[string]interface
 			Protocol:  defaultString(asString(item["protocol"]), "tls"),
 			Strategy:  defaultString(asString(item["strategy"]), "round"),
 			ChainType: 1,
+			Port:      port,
 		})
 	}
 	if len(state.InNodes) == 0 {
 		return nil, errors.New("入口不能为空")
 	}
 
-	if tunnelType == 2 {
+	if tunnelType == 2 || tunnelType == 3 {
 		outNodesRaw := asMapSlice(req["outNodeId"])
 		if len(outNodesRaw) == 0 {
 			return nil, errors.New("出口不能为空")
 		}
 
-		allocated := map[int64]int{}
 		for _, item := range outNodesRaw {
 			nodeID := asInt64(item["nodeId"], 0)
 			if nodeID <= 0 {
@@ -2138,8 +2171,61 @@ func (h *Handler) prepareTunnelCreateState(tx *gorm.DB, req map[string]interface
 			}
 		}
 	}
+	if tunnelType == 3 {
+		for _, inNode := range state.InNodes {
+			if err := validateRemoteNodePort(state.Nodes[inNode.NodeID], inNode.Port); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if tunnelType == 3 {
+		if len(state.InNodes) != 1 {
+			return nil, fmt.Errorf("TUN隧道拓扑非法：仅允许单入口，当前 %d 个", len(state.InNodes))
+		}
+		if len(state.OutNodes) != 1 {
+			return nil, fmt.Errorf("TUN隧道拓扑非法：仅允许单出口，当前 %d 个", len(state.OutNodes))
+		}
+	}
 
 	return state, nil
+}
+
+func normalizeTunnelTunConfig(raw interface{}) map[string]interface{} {
+	m, ok := raw.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return map[string]interface{}{}
+	}
+	out := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		key := strings.TrimSpace(k)
+		if key == "" {
+			continue
+		}
+		out[key] = v
+	}
+	if len(out) == 0 {
+		return map[string]interface{}{}
+	}
+	return out
+}
+
+func ensureTunnelTunConfig(state *tunnelCreateState) {
+	if state == nil || state.Type != 3 {
+		return
+	}
+	cfg := normalizeTunnelTunConfig(state.TunConfig)
+	if strings.TrimSpace(asString(cfg["name"])) == "" {
+		if state.TunnelID > 0 {
+			cfg["name"] = fmt.Sprintf("tun_%d", state.TunnelID)
+		} else {
+			cfg["name"] = "tun_runtime"
+		}
+	}
+	if asInt(cfg["mtu"], 0) <= 0 {
+		cfg["mtu"] = 1420
+	}
+	state.TunConfig = cfg
 }
 
 func buildTunnelInIP(inNodes []tunnelRuntimeNode, nodes map[int64]*nodeRecord, ipPreference string) string {
@@ -2188,6 +2274,17 @@ func applyTunnelPortsToRequest(req map[string]interface{}, state *tunnelCreateSt
 	if req == nil || state == nil {
 		return
 	}
+	inPorts := make(map[int64]int)
+	for _, n := range state.InNodes {
+		inPorts[n.NodeID] = n.Port
+	}
+	for _, item := range asMapSlice(req["inNodeId"]) {
+		nodeID := asInt64(item["nodeId"], 0)
+		if port, ok := inPorts[nodeID]; ok && port > 0 {
+			item["port"] = port
+		}
+	}
+
 	outPorts := make(map[int64]int)
 	for _, n := range state.OutNodes {
 		outPorts[n.NodeID] = n.Port
@@ -2490,8 +2587,18 @@ func (h *Handler) applyTunnelRuntime(state *tunnelCreateState) ([]int64, []int64
 	}
 	createdChains := make([]int64, 0)
 	createdServices := make([]int64, 0)
-	if state.Type != 2 {
+	if state.Type != 2 && state.Type != 3 {
 		return createdChains, createdServices, nil
+	}
+	if state.Type == 2 {
+		return h.applyTunnelChainRuntime(state, createdChains, createdServices)
+	}
+	return h.applyTunnelTunRuntime(state, createdChains, createdServices)
+}
+
+func (h *Handler) applyTunnelChainRuntime(state *tunnelCreateState, createdChains []int64, createdServices []int64) ([]int64, []int64, error) {
+	if state == nil {
+		return createdChains, createdServices, errors.New("invalid tunnel runtime state")
 	}
 
 	for _, inNode := range state.InNodes {
@@ -2512,6 +2619,82 @@ func (h *Handler) applyTunnelRuntime(state *tunnelCreateState) ([]int64, []int64
 		}
 		createdChains = append(createdChains, inNode.NodeID)
 	}
+
+	for i, hop := range state.ChainHops {
+		nextTargets := state.OutNodes
+		if i+1 < len(state.ChainHops) {
+			nextTargets = state.ChainHops[i+1]
+		}
+		for _, chainNode := range hop {
+			if node := state.Nodes[chainNode.NodeID]; node != nil && node.IsRemote == 1 {
+				continue
+			}
+			chainData, err := buildTunnelChainConfig(state.TunnelID, chainNode.NodeID, nextTargets, state.Nodes, state.IPPreference)
+			if err != nil {
+				return createdChains, createdServices, err
+			}
+			if _, err := h.sendNodeCommand(chainNode.NodeID, "AddChains", chainData, true, false); err != nil {
+				return createdChains, createdServices, fmt.Errorf("转发链节点 %s 下发转发链失败: %w", nodeDisplayName(state.Nodes[chainNode.NodeID]), err)
+			}
+			createdChains = append(createdChains, chainNode.NodeID)
+
+			serviceData := buildTunnelChainServiceConfig(state.TunnelID, chainNode, state.Nodes[chainNode.NodeID])
+			if _, err := h.sendNodeCommand(chainNode.NodeID, "AddService", serviceData, true, false); err != nil {
+				return createdChains, createdServices, fmt.Errorf("转发链节点 %s 下发服务失败: %w", nodeDisplayName(state.Nodes[chainNode.NodeID]), err)
+			}
+			createdServices = append(createdServices, chainNode.NodeID)
+		}
+	}
+
+	for _, outNode := range state.OutNodes {
+		if node := state.Nodes[outNode.NodeID]; node != nil && node.IsRemote == 1 {
+			continue
+		}
+		serviceData := buildTunnelChainServiceConfig(state.TunnelID, outNode, state.Nodes[outNode.NodeID])
+		if _, err := h.sendNodeCommand(outNode.NodeID, "AddService", serviceData, true, false); err != nil {
+			return createdChains, createdServices, fmt.Errorf("出口节点 %s 下发服务失败: %w", nodeDisplayName(state.Nodes[outNode.NodeID]), err)
+		}
+		createdServices = append(createdServices, outNode.NodeID)
+	}
+
+	return createdChains, createdServices, nil
+}
+
+func (h *Handler) applyTunnelTunRuntime(state *tunnelCreateState, createdChains []int64, createdServices []int64) ([]int64, []int64, error) {
+	if state == nil {
+		return createdChains, createdServices, errors.New("invalid tunnel runtime state")
+	}
+	if len(state.InNodes) != 1 {
+		return createdChains, createdServices, fmt.Errorf("TUN隧道拓扑非法：仅允许单入口，当前 %d 个", len(state.InNodes))
+	}
+	if len(state.OutNodes) != 1 {
+		return createdChains, createdServices, fmt.Errorf("TUN隧道拓扑非法：仅允许单出口，当前 %d 个", len(state.OutNodes))
+	}
+	ensureTunnelTunConfig(state)
+
+	inNode := state.InNodes[0]
+	targets := state.OutNodes
+	if len(state.ChainHops) > 0 {
+		targets = state.ChainHops[0]
+	}
+	chainData, err := buildTunnelChainConfig(state.TunnelID, inNode.NodeID, targets, state.Nodes, state.IPPreference)
+	if err != nil {
+		return createdChains, createdServices, err
+	}
+	if _, err := h.sendNodeCommand(inNode.NodeID, "AddChains", chainData, true, false); err != nil {
+		node := state.Nodes[inNode.NodeID]
+		if node != nil && node.IsRemote == 1 && shouldDeferTunnelRuntimeApplyError(err) {
+			return createdChains, createdServices, nil
+		}
+		return createdChains, createdServices, fmt.Errorf("TUN入口节点 %s 下发转发链失败: %w", nodeDisplayName(node), err)
+	}
+	createdChains = append(createdChains, inNode.NodeID)
+
+	serviceData := buildTunnelTunServiceConfig(state.TunnelID, inNode, state.Nodes[inNode.NodeID], state.TunConfig)
+	if _, err := h.sendNodeCommand(inNode.NodeID, "AddService", serviceData, true, false); err != nil {
+		return createdChains, createdServices, fmt.Errorf("TUN入口节点 %s 下发服务失败: %w", nodeDisplayName(state.Nodes[inNode.NodeID]), err)
+	}
+	createdServices = append(createdServices, inNode.NodeID)
 
 	for i, hop := range state.ChainHops {
 		nextTargets := state.OutNodes
@@ -2684,6 +2867,55 @@ func buildTunnelChainServiceConfig(tunnelID int64, chainNode tunnelRuntimeNode, 
 	return []map[string]interface{}{service}
 }
 
+func buildTunnelTunServiceConfig(tunnelID int64, inNode tunnelRuntimeNode, node *nodeRecord, tunConfig map[string]interface{}) []map[string]interface{} {
+	if node == nil {
+		return nil
+	}
+	tunCfg := normalizeTunnelTunConfig(tunConfig)
+	if strings.TrimSpace(asString(tunCfg["name"])) == "" {
+		tunCfg["name"] = fmt.Sprintf("tun_%d", tunnelID)
+	}
+	if asInt(tunCfg["mtu"], 0) <= 0 {
+		tunCfg["mtu"] = 1420
+	}
+
+	listenerMetadata := map[string]interface{}{
+		"tunConfig": tunCfg,
+	}
+	for _, key := range []string{"name", "net", "route", "routes", "gw", "dns", "peer", "mtu", "router"} {
+		if v, ok := tunCfg[key]; ok {
+			listenerMetadata[key] = v
+		}
+	}
+
+	listenHost := strings.TrimSpace(node.UDPListenAddr)
+	if listenHost == "" {
+		listenHost = strings.TrimSpace(node.TCPListenAddr)
+	}
+	if listenHost == "" {
+		listenHost = "[::]"
+	}
+
+	service := map[string]interface{}{
+		"name": fmt.Sprintf("%d_tls", tunnelID),
+		"addr": fmt.Sprintf("%s:%d", listenHost, inNode.Port),
+		"handler": map[string]interface{}{
+			"type":     "tun",
+			"chain":    fmt.Sprintf("chains_%d", tunnelID),
+			"metadata": map[string]interface{}{"tunConfig": tunCfg},
+		},
+		"listener": map[string]interface{}{
+			"type":     "tun",
+			"metadata": listenerMetadata,
+		},
+		"metadata": map[string]interface{}{
+			"tunConfig": tunCfg,
+		},
+	}
+
+	return []map[string]interface{}{service}
+}
+
 func selectTunnelDialHost(fromNode, toNode *nodeRecord, ipPreference string) (string, error) {
 	if fromNode == nil || toNode == nil {
 		return "", errors.New("节点不存在")
@@ -2813,12 +3045,17 @@ func (h *Handler) replaceTunnelChainsTx(tx *gorm.DB, tunnelID int64, req map[str
 		if nodeID <= 0 {
 			continue
 		}
+		entryPort := asInt(n["port"], 0)
+		entryPortNull := sql.NullInt64{}
+		if entryPort > 0 {
+			entryPortNull = sql.NullInt64{Int64: int64(entryPort), Valid: true}
+		}
 		if err := h.repo.CreateChainTunnelTx(
 			tx,
 			tunnelID,
 			"1",
 			nodeID,
-			sql.NullInt64{},
+			entryPortNull,
 			defaultString(asString(n["strategy"]), "round"),
 			i+1,
 			defaultString(asString(n["protocol"]), "tls"),

--- a/go-backend/internal/store/model/model.go
+++ b/go-backend/internal/store/model/model.go
@@ -113,6 +113,7 @@ type Tunnel struct {
 	Name         string         `gorm:"type:varchar(100);not null"`
 	TrafficRatio float64        `gorm:"column:traffic_ratio;not null;default:1.0"`
 	Type         int            `gorm:"not null"`
+	TunConfig    sql.NullString `gorm:"column:tun_config;type:text"`
 	Protocol     string         `gorm:"type:varchar(10);not null;default:'tls'"`
 	Flow         int64          `gorm:"not null"`
 	CreatedTime  int64          `gorm:"column:created_time;not null"`
@@ -361,6 +362,7 @@ type TunnelBackup struct {
 	Name         string              `json:"name"`
 	TrafficRatio float64             `json:"trafficRatio"`
 	Type         int                 `json:"type"`
+	TunConfig    string              `json:"tunConfig,omitempty"`
 	Protocol     string              `json:"protocol"`
 	Flow         int64               `json:"flow"`
 	CreatedTime  int64               `json:"createdTime"`

--- a/go-backend/internal/store/repo/repository.go
+++ b/go-backend/internal/store/repo/repository.go
@@ -271,7 +271,7 @@ func prepareSQLiteLegacyColumns(db *gorm.DB) error {
 	}
 
 	if m.HasTable(&model.Tunnel{}) {
-		for _, field := range []string{"Inx", "IPPreference"} {
+		for _, field := range []string{"Inx", "IPPreference", "TunConfig"} {
 			if m.HasColumn(&model.Tunnel{}, field) {
 				continue
 			}
@@ -816,6 +816,7 @@ func (r *Repository) ListTunnels() ([]map[string]interface{}, error) {
 			"status": t.Status, "createdTime": t.CreatedTime,
 			"inIp":         nullableString(t.InIP),
 			"ipPreference": t.IPPreference,
+			"tunConfig":    nullableString(t.TunConfig),
 			"inNodeId":     make([]map[string]interface{}, 0),
 			"outNodeId":    make([]map[string]interface{}, 0),
 			"chainNodes":   make([][]map[string]interface{}, 0),
@@ -1717,6 +1718,9 @@ func (r *Repository) exportTunnels() ([]model.TunnelBackup, error) {
 		if t.InIP.Valid {
 			b.InIP = t.InIP.String
 		}
+		if t.TunConfig.Valid {
+			b.TunConfig = t.TunConfig.String
+		}
 		chains, err := r.exportChainTunnels(t.ID)
 		if err != nil {
 			return nil, err
@@ -2067,6 +2071,7 @@ func importTunnels(tx *gorm.DB, tunnels []model.TunnelBackup, now int64) (int, e
 			Name:         t.Name,
 			TrafficRatio: t.TrafficRatio,
 			Type:         t.Type,
+			TunConfig:    sql.NullString{},
 			Protocol:     t.Protocol,
 			Flow:         t.Flow,
 			CreatedTime:  t.CreatedTime,
@@ -2076,10 +2081,14 @@ func importTunnels(tx *gorm.DB, tunnels []model.TunnelBackup, now int64) (int, e
 			Inx:          t.Inx,
 			IPPreference: t.IPPreference,
 		}
+		if t.Type == 3 {
+			trimmedTunConfig := strings.TrimSpace(t.TunConfig)
+			item.TunConfig = sql.NullString{String: trimmedTunConfig, Valid: trimmedTunConfig != ""}
+		}
 		err := tx.Clauses(clause.OnConflict{
 			Columns: []clause.Column{{Name: "id"}},
 			DoUpdates: clause.AssignmentColumns([]string{
-				"name", "traffic_ratio", "type", "protocol", "flow", "updated_time", "status", "in_ip", "inx", "ip_preference",
+				"name", "traffic_ratio", "type", "tun_config", "protocol", "flow", "updated_time", "status", "in_ip", "inx", "ip_preference",
 			}),
 		}).Create(&item).Error
 		if err != nil {
@@ -2467,11 +2476,12 @@ func (r *Repository) GetUserTunnelByID(id int64) (*model.UserTunnel, error) {
 
 // ─── Migration ───────────────────────────────────────────────────────
 
-const currentSchemaVersion = 4
+const currentSchemaVersion = 5
 
 var ensurePostgresIDDefaultsFn = ensurePostgresIDDefaults
 var migrateViteConfigValueColumnTypeFn = migrateViteConfigValueColumnType
 var migrateSpeedLimitTunnelBindingFn = migrateSpeedLimitTunnelBinding
+var migrateTunnelTunConfigFn = migrateTunnelTunConfig
 
 func getSchemaVersion(db *gorm.DB) int {
 	var v model.SchemaVersion
@@ -2535,6 +2545,12 @@ func migrateSchema(db *gorm.DB) error {
 		}
 	}
 
+	if ver < 5 {
+		if err := migrateTunnelTunConfigFn(db); err != nil {
+			return err
+		}
+	}
+
 	setSchemaVersion(db, currentSchemaVersion)
 	return nil
 }
@@ -2594,6 +2610,30 @@ func migrateSpeedLimitTunnelBinding(db *gorm.DB) error {
 			"tunnel_name": nil,
 		}).Error; err != nil {
 		return fmt.Errorf("clear speed_limit tunnel binding: %w", err)
+	}
+
+	return nil
+}
+
+func migrateTunnelTunConfig(db *gorm.DB) error {
+	if db == nil {
+		return errors.New("nil db")
+	}
+
+	m := db.Migrator()
+	if !m.HasTable(&model.Tunnel{}) {
+		return nil
+	}
+	if !m.HasColumn(&model.Tunnel{}, "TunConfig") {
+		if err := m.AddColumn(&model.Tunnel{}, "TunConfig"); err != nil {
+			return fmt.Errorf("add tunnel.tun_config column: %w", err)
+		}
+	}
+
+	if err := db.Model(&model.Tunnel{}).
+		Where("type <> 3").
+		Update("tun_config", nil).Error; err != nil {
+		return fmt.Errorf("normalize tunnel.tun_config: %w", err)
 	}
 
 	return nil

--- a/go-backend/internal/store/repo/repository_migrate_test.go
+++ b/go-backend/internal/store/repo/repository_migrate_test.go
@@ -8,6 +8,8 @@ import (
 	gsqlite "github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+
+	"go-backend/internal/store/model"
 )
 
 func TestMigrateSchemaRunsPostgresIDRepairEvenAtCurrentVersion(t *testing.T) {
@@ -240,6 +242,68 @@ func TestMigrateSchemaClearsSpeedLimitTunnelBinding(t *testing.T) {
 	}
 	if tunnelName.Valid {
 		t.Fatalf("expected tunnel_name cleared to NULL, got %q", tunnelName.String)
+	}
+
+	var schemaVersion int
+	if err := db.Raw(`SELECT version FROM schema_version LIMIT 1`).Row().Scan(&schemaVersion); err != nil {
+		t.Fatalf("query schema_version: %v", err)
+	}
+	if schemaVersion != currentSchemaVersion {
+		t.Fatalf("expected schema version %d, got %d", currentSchemaVersion, schemaVersion)
+	}
+}
+
+func TestMigrateSchemaAddsTunnelTunConfigColumn(t *testing.T) {
+	db, err := gorm.Open(gsqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	if err := db.Exec(`CREATE TABLE schema_version (version INTEGER NOT NULL DEFAULT 0)`).Error; err != nil {
+		t.Fatalf("create schema_version: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO schema_version(version) VALUES(?)`, 4).Error; err != nil {
+		t.Fatalf("seed schema_version: %v", err)
+	}
+	if err := db.Exec(`
+		CREATE TABLE tunnel (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name VARCHAR(100) NOT NULL,
+			traffic_ratio REAL NOT NULL DEFAULT 1.0,
+			type INTEGER NOT NULL,
+			protocol VARCHAR(10) NOT NULL DEFAULT 'tls',
+			flow INTEGER NOT NULL,
+			created_time INTEGER NOT NULL,
+			updated_time INTEGER NOT NULL,
+			status INTEGER NOT NULL,
+			in_ip TEXT,
+			inx INTEGER NOT NULL DEFAULT 0,
+			ip_preference VARCHAR(10) NOT NULL DEFAULT ''
+		)
+	`).Error; err != nil {
+		t.Fatalf("create tunnel: %v", err)
+	}
+
+	originalIDRepair := ensurePostgresIDDefaultsFn
+	ensurePostgresIDDefaultsFn = func(db *gorm.DB) error { return nil }
+	t.Cleanup(func() {
+		ensurePostgresIDDefaultsFn = originalIDRepair
+	})
+
+	if err := migrateSchema(db); err != nil {
+		t.Fatalf("migrateSchema: %v", err)
+	}
+
+	if !db.Migrator().HasColumn(&model.Tunnel{}, "TunConfig") {
+		t.Fatalf("expected tunnel.tun_config column to be added")
 	}
 
 	var schemaVersion int

--- a/go-backend/internal/store/repo/repository_mutations.go
+++ b/go-backend/internal/store/repo/repository_mutations.go
@@ -370,9 +370,13 @@ func (r *Repository) UpdateTunnelOrder(tunnelID int64, inx int, now int64) {
 		Updates(map[string]interface{}{"inx": inx, "updated_time": now}).Error
 }
 
-func (r *Repository) UpdateTunnelTx(tx *gorm.DB, tunnelID int64, name string, typeVal int, flow int64, trafficRatio float64, status int, inIP, ipPreference string, now int64) error {
+func (r *Repository) UpdateTunnelTx(tx *gorm.DB, tunnelID int64, name string, typeVal int, flow int64, trafficRatio float64, status int, inIP, ipPreference, tunConfig string, now int64) error {
 	if tx == nil {
 		return errors.New("database unavailable")
+	}
+	tunConfigValue := sql.NullString{}
+	if typeVal == 3 {
+		tunConfigValue = nullStringFromInterface(strings.TrimSpace(tunConfig))
 	}
 	return tx.Model(&model.Tunnel{}).
 		Where("id = ?", tunnelID).
@@ -384,6 +388,7 @@ func (r *Repository) UpdateTunnelTx(tx *gorm.DB, tunnelID int64, name string, ty
 			"status":        status,
 			"in_ip":         nullStringFromInterface(inIP),
 			"ip_preference": ipPreference,
+			"tun_config":    tunConfigValue,
 			"updated_time":  now,
 		}).Error
 }
@@ -1228,12 +1233,17 @@ func (r *Repository) BatchUpdateForwardStatus(ids []int64, status int) (int, int
 	return s, f
 }
 
-func (r *Repository) CreateTunnelTx(tx *gorm.DB, name string, trafficRatio float64, typeVal int, flow int64, now int64, status int, inIP interface{}, inx int, ipPreference string) (int64, error) {
+func (r *Repository) CreateTunnelTx(tx *gorm.DB, name string, trafficRatio float64, typeVal int, flow int64, now int64, status int, inIP interface{}, inx int, ipPreference, tunConfig string) (int64, error) {
 	inIPVal := nullStringFromInterface(inIP)
+	tunConfigVal := sql.NullString{}
+	if typeVal == 3 {
+		tunConfigVal = nullStringFromInterface(strings.TrimSpace(tunConfig))
+	}
 	tunnel := model.Tunnel{
 		Name:         name,
 		TrafficRatio: trafficRatio,
 		Type:         typeVal,
+		TunConfig:    tunConfigVal,
 		Protocol:     "tls",
 		Flow:         flow,
 		CreatedTime:  now,

--- a/go-backend/internal/store/repo/repository_tunnel_tun_config_test.go
+++ b/go-backend/internal/store/repo/repository_tunnel_tun_config_test.go
@@ -1,0 +1,154 @@
+package repo
+
+import (
+	"database/sql"
+	"testing"
+
+	gsqlite "github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"go-backend/internal/store/model"
+)
+
+func openTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(gsqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	})
+	return db
+}
+
+func TestListTunnelsReturnsTunConfig(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.AutoMigrate(&model.Node{}, &model.Tunnel{}, &model.ChainTunnel{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+
+	tunnel := model.Tunnel{
+		Name:         "tun-1",
+		TrafficRatio: 1,
+		Type:         3,
+		TunConfig:    sql.NullString{String: `{"mode":"auto"}`, Valid: true},
+		Protocol:     "tls",
+		Flow:         1,
+		CreatedTime:  1,
+		UpdatedTime:  1,
+		Status:       1,
+		Inx:          1,
+	}
+	if err := db.Create(&tunnel).Error; err != nil {
+		t.Fatalf("create tunnel: %v", err)
+	}
+
+	r := &Repository{db: db}
+	items, err := r.ListTunnels()
+	if err != nil {
+		t.Fatalf("list tunnels: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 tunnel, got %d", len(items))
+	}
+	if got := items[0]["tunConfig"]; got != `{"mode":"auto"}` {
+		t.Fatalf("expected tunConfig to be preserved, got %#v", got)
+	}
+}
+
+func TestExportAndImportTunnelsWithTunConfig(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.AutoMigrate(&model.Tunnel{}, &model.ChainTunnel{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+
+	r := &Repository{db: db}
+	if err := db.Create(&model.Tunnel{
+		ID:           10,
+		Name:         "tun-export",
+		TrafficRatio: 1,
+		Type:         3,
+		TunConfig:    sql.NullString{String: `{"dev":"tun0"}`, Valid: true},
+		Protocol:     "tls",
+		Flow:         1,
+		CreatedTime:  1,
+		UpdatedTime:  1,
+		Status:       1,
+		Inx:          1,
+	}).Error; err != nil {
+		t.Fatalf("seed tunnel: %v", err)
+	}
+
+	exported, err := r.exportTunnels()
+	if err != nil {
+		t.Fatalf("export tunnels: %v", err)
+	}
+	if len(exported) != 1 {
+		t.Fatalf("expected 1 exported tunnel, got %d", len(exported))
+	}
+	if exported[0].TunConfig != `{"dev":"tun0"}` {
+		t.Fatalf("expected exported tunConfig, got %q", exported[0].TunConfig)
+	}
+
+	if err := db.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&model.Tunnel{}).Error; err != nil {
+		t.Fatalf("clear tunnels: %v", err)
+	}
+
+	importRows := []model.TunnelBackup{
+		{
+			ID:           21,
+			Name:         "normal",
+			TrafficRatio: 1,
+			Type:         1,
+			TunConfig:    `{"should":"clear"}`,
+			Protocol:     "tls",
+			Flow:         1,
+			CreatedTime:  2,
+			UpdatedTime:  2,
+			Status:       1,
+			Inx:          1,
+		},
+		{
+			ID:           22,
+			Name:         "tun",
+			TrafficRatio: 1,
+			Type:         3,
+			TunConfig:    `{"dev":"tun1"}`,
+			Protocol:     "tls",
+			Flow:         1,
+			CreatedTime:  2,
+			UpdatedTime:  2,
+			Status:       1,
+			Inx:          2,
+		},
+	}
+
+	count, err := importTunnels(db, importRows, 3)
+	if err != nil {
+		t.Fatalf("import tunnels: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 imported tunnels, got %d", count)
+	}
+
+	var normal model.Tunnel
+	if err := db.Where("id = ?", 21).First(&normal).Error; err != nil {
+		t.Fatalf("query normal tunnel: %v", err)
+	}
+	if normal.TunConfig.Valid {
+		t.Fatalf("expected type=1 tunnel tun_config to be NULL, got %q", normal.TunConfig.String)
+	}
+
+	var tun model.Tunnel
+	if err := db.Where("id = ?", 22).First(&tun).Error; err != nil {
+		t.Fatalf("query type=3 tunnel: %v", err)
+	}
+	if !tun.TunConfig.Valid || tun.TunConfig.String != `{"dev":"tun1"}` {
+		t.Fatalf("expected type=3 tun_config persisted, got %#v", tun.TunConfig)
+	}
+}

--- a/go-backend/tests/contract/tunnel_create_contract_test.go
+++ b/go-backend/tests/contract/tunnel_create_contract_test.go
@@ -128,6 +128,50 @@ func TestTunnelUpdateAssignsChainPortsContract(t *testing.T) {
 	}
 }
 
+func TestTunnelCreateType3RejectsMultiEntryTopologyContract(t *testing.T) {
+	secret := "contract-jwt-secret"
+	router, repo := setupContractRouter(t, secret)
+	now := time.Now().UnixMilli()
+
+	adminToken, err := auth.GenerateToken(1, "admin_user", 0, secret)
+	if err != nil {
+		t.Fatalf("generate admin token: %v", err)
+	}
+
+	insertNode := func(name, ip, portRange string) int64 {
+		if err := repo.DB().Exec(`
+			INSERT INTO node(name, secret, server_ip, server_ip_v4, server_ip_v6, port, interface_name, version, http, tls, socks, created_time, updated_time, status, tcp_listen_addr, udp_listen_addr, inx)
+			VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, name, name+"-secret", ip, ip, "", portRange, "", "v1", 1, 1, 1, now, now, 1, "[::]", "[::]", 0).Error; err != nil {
+			t.Fatalf("insert node %s: %v", name, err)
+		}
+		return mustLastInsertID(t, repo, name)
+	}
+
+	entry1 := insertNode("tun-e1", "10.40.0.1", "43000-43010")
+	entry2 := insertNode("tun-e2", "10.40.0.2", "43100-43110")
+	exitID := insertNode("tun-x1", "10.40.0.3", "43200-43210")
+
+	payload := `{"name":"tun-topology-invalid","type":3,"flow":99999,"status":1,"inNodeId":[{"nodeId":` + jsonInt(entry1) + `,"protocol":"tls"},{"nodeId":` + jsonInt(entry2) + `,"protocol":"tls"}],"chainNodes":[],"outNodeId":[{"nodeId":` + jsonInt(exitID) + `,"protocol":"tls"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tunnel/create", bytes.NewBufferString(payload))
+	req.Header.Set("Authorization", adminToken)
+	req.Header.Set("Content-Type", "application/json")
+	res := httptest.NewRecorder()
+
+	router.ServeHTTP(res, req)
+
+	var out response.R
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out.Code == 0 {
+		t.Fatalf("expected topology validation failure")
+	}
+	if !strings.Contains(out.Msg, "仅允许单入口") {
+		t.Fatalf("expected clear topology error, got %q", out.Msg)
+	}
+}
+
 func jsonInt(v int64) string {
 	return strconv.FormatInt(v, 10)
 }

--- a/go-gost/main.go
+++ b/go-gost/main.go
@@ -109,12 +109,12 @@ func main() {
 	// 加载配置文件
 	config, err := LoadConfig("config.json")
 	if err != nil {
-		fmt.Println("❌ 配置加载失败: %v\n", err)
+		fmt.Printf("❌ 配置加载失败: %v\n", err)
 		fmt.Println("请确保当前目录存在 config.json 文件")
 		os.Exit(1)
 	}
 
-	fmt.Println("✅ 配置加载成功 - addr: %s", config.Addr)
+	fmt.Printf("✅ 配置加载成功 - addr: %s\n", config.Addr)
 
 	log := xlogger.NewLogger()
 	logger.SetDefault(log)

--- a/vite-frontend/src/api/diagnosis-stream.ts
+++ b/vite-frontend/src/api/diagnosis-stream.ts
@@ -1,6 +1,7 @@
+import type { TunnelDiagnosisApiItem } from "@/api/types";
+
 import axios from "axios";
 
-import type { TunnelDiagnosisApiItem } from "@/api/types";
 import { clearSession, getToken } from "@/utils/session";
 
 const DIAGNOSIS_STREAM_TIMEOUT_MS = 2 * 60 * 1000;
@@ -106,13 +107,16 @@ const combineAbortSignals = (signals: AbortSignal[]): AbortSignal => {
       controller.abort();
     }
   };
+
   signals.forEach((signal) => {
     if (signal.aborted) {
       onAbort();
+
       return;
     }
     signal.addEventListener("abort", onAbort, { once: true });
   });
+
   return controller.signal;
 };
 
@@ -120,6 +124,7 @@ const parseMessage = (err: unknown, fallback: string): string => {
   if (err instanceof Error && err.message) {
     return err.message;
   }
+
   return fallback;
 };
 
@@ -133,7 +138,12 @@ const runDiagnosisStream = async ({
   onError,
 }: RunDiagnosisStreamOptions): Promise<DiagnosisStreamRunResult> => {
   if (!isStreamSupported()) {
-    return { fallback: true, completed: false, timedOut: false, receivedItems: 0 };
+    return {
+      fallback: true,
+      completed: false,
+      timedOut: false,
+      receivedItems: 0,
+    };
   }
 
   let receivedItems = 0;
@@ -170,27 +180,51 @@ const runDiagnosisStream = async ({
 
     if (response.status === 401) {
       handleTokenExpired();
-      return { fallback: false, completed: false, timedOut: false, receivedItems };
+
+      return {
+        fallback: false,
+        completed: false,
+        timedOut: false,
+        receivedItems,
+      };
     }
 
     if (response.status === 404) {
-      return { fallback: true, completed: false, timedOut: false, receivedItems };
+      return {
+        fallback: true,
+        completed: false,
+        timedOut: false,
+        receivedItems,
+      };
     }
 
     if (!response.ok || !response.body) {
       const fallbackMessage = `请求失败(${response.status})`;
       let message = fallbackMessage;
+
       try {
         const data = (await response.json()) as RawObject;
+
         if (typeof data.msg === "string" && data.msg.trim()) {
           message = data.msg;
         }
       } catch {}
       if (receivedItems === 0) {
-        return { fallback: true, completed: false, timedOut: false, receivedItems };
+        return {
+          fallback: true,
+          completed: false,
+          timedOut: false,
+          receivedItems,
+        };
       }
       onError?.(message);
-      return { fallback: false, completed: false, timedOut: false, receivedItems };
+
+      return {
+        fallback: false,
+        completed: false,
+        timedOut: false,
+        receivedItems,
+      };
     }
 
     const reader = response.body.getReader();
@@ -202,6 +236,7 @@ const runDiagnosisStream = async ({
         return;
       }
       let parsed: DiagnosisStreamRawEvent;
+
       try {
         parsed = JSON.parse(line) as DiagnosisStreamRawEvent;
       } catch {
@@ -209,15 +244,18 @@ const runDiagnosisStream = async ({
       }
 
       const eventType = (parsed.type || "").toLowerCase();
+
       if (eventType === "start") {
         if (parsed.data && typeof parsed.data === "object") {
           const startData = parsed.data as RawObject;
           const startTotal = Number(startData.total);
+
           if (Number.isFinite(startTotal) && startTotal >= 0) {
             currentProgress = { ...currentProgress, total: startTotal };
           }
           onStart?.(startData);
         }
+
         return;
       }
 
@@ -228,10 +266,12 @@ const runDiagnosisStream = async ({
         const itemData = parsed.data as RawObject;
         const index = Number(itemData.index);
         const result = itemData.result as TunnelDiagnosisApiItem | undefined;
+
         if (!Number.isFinite(index) || !result || typeof result !== "object") {
           return;
         }
         const progress = normalizeProgress(itemData.progress, currentProgress);
+
         currentProgress = progress;
         receivedItems += 1;
         onItem({
@@ -239,6 +279,7 @@ const runDiagnosisStream = async ({
           result,
           progress,
         });
+
         return;
       }
 
@@ -252,6 +293,7 @@ const runDiagnosisStream = async ({
           donePayload.progress ?? donePayload,
           currentProgress,
         );
+
         if (typeof donePayload.timedOut === "boolean") {
           doneProgress.timedOut = donePayload.timedOut;
           timedOut = donePayload.timedOut;
@@ -263,16 +305,19 @@ const runDiagnosisStream = async ({
 
     while (true) {
       const { value, done } = await reader.read();
+
       if (done) {
         break;
       }
       buffer += decoder.decode(value, { stream: true });
       const lines = buffer.split("\n");
+
       buffer = lines.pop() ?? "";
       lines.forEach((line) => processLine(line.trim()));
     }
 
     const tail = buffer.trim();
+
     if (tail) {
       processLine(tail);
     }
@@ -282,6 +327,7 @@ const runDiagnosisStream = async ({
         ...currentProgress,
         timedOut: true,
       };
+
       onDone?.(timeoutProgress);
     }
 
@@ -297,20 +343,43 @@ const runDiagnosisStream = async ({
         ...currentProgress,
         timedOut: true,
       };
+
       onDone?.(timeoutProgress);
-      return { fallback: false, completed: false, timedOut: true, receivedItems };
+
+      return {
+        fallback: false,
+        completed: false,
+        timedOut: true,
+        receivedItems,
+      };
     }
 
     if (signal?.aborted) {
-      return { fallback: false, completed: false, timedOut: false, receivedItems };
+      return {
+        fallback: false,
+        completed: false,
+        timedOut: false,
+        receivedItems,
+      };
     }
 
     if (receivedItems === 0) {
-      return { fallback: true, completed: false, timedOut: false, receivedItems };
+      return {
+        fallback: true,
+        completed: false,
+        timedOut: false,
+        receivedItems,
+      };
     }
 
     onError?.(parseMessage(error, "流式诊断中断"));
-    return { fallback: false, completed: false, timedOut: false, receivedItems };
+
+    return {
+      fallback: false,
+      completed: false,
+      timedOut: false,
+      receivedItems,
+    };
   } finally {
     clearTimeout(timeoutId);
   }

--- a/vite-frontend/src/api/types.ts
+++ b/vite-frontend/src/api/types.ts
@@ -35,6 +35,19 @@ export interface TunnelApiItem {
   status: number;
   entryNodeId: number;
   exitNodeId: number;
+  tunConfig?: {
+    net?: string;
+    mtu?: number;
+    routes?: string | string[];
+    dns?: string | string[];
+    peer?: string | string[];
+    gw?: string;
+    keepalive?: number;
+    ttl?: number;
+    passphrase?: string;
+    p2p?: boolean;
+    tunName?: string;
+  };
   inx?: number;
   [key: string]: unknown;
 }
@@ -247,6 +260,19 @@ export interface TunnelMutationPayload {
   inNodeId?: TunnelChainNodePayload[];
   outNodeId?: TunnelChainNodePayload[];
   chainNodes?: TunnelChainNodePayload[][];
+  tunConfig?: {
+    net: string;
+    mtu?: number;
+    routes?: string;
+    dns?: string;
+    peer?: string;
+    gw?: string;
+    keepalive?: number;
+    ttl?: number;
+    passphrase?: string;
+    p2p?: boolean;
+    tunName?: string;
+  };
 }
 
 export interface UserTunnelAssignPayload {

--- a/vite-frontend/src/pages/forward.tsx
+++ b/vite-frontend/src/pages/forward.tsx
@@ -875,6 +875,7 @@ export default function ForwardPage() {
   const handleDiagnose = async (forward: Forward) => {
     diagnosisAbortRef.current?.abort();
     const abortController = new AbortController();
+
     diagnosisAbortRef.current = abortController;
 
     setCurrentDiagnosisForward(forward);
@@ -908,6 +909,7 @@ export default function ForwardPage() {
             const startItems = Array.isArray(payload.items)
               ? (payload.items as ForwardDiagnosisResult["results"])
               : [];
+
             setDiagnosisResult((prev) => ({
               forwardName: startForwardName,
               timestamp: Date.now(),
@@ -947,6 +949,7 @@ export default function ForwardPage() {
                   diagnosing: false,
                 });
               }
+
               return {
                 ...base,
                 timestamp: Date.now(),
@@ -982,8 +985,11 @@ export default function ForwardPage() {
 
         if (response.code === 0) {
           const resultData = response.data as ForwardDiagnosisResult;
-          const successCount = resultData.results.filter((r) => r.success).length;
+          const successCount = resultData.results.filter(
+            (r) => r.success,
+          ).length;
           const failedCount = resultData.results.length - successCount;
+
           setDiagnosisResult(resultData);
           setDiagnosisProgress({
             total: resultData.results.length,
@@ -1385,10 +1391,15 @@ export default function ForwardPage() {
     const activeTunnelGroupKey = buildForwardTunnelGroupKey(
       activeForward?.tunnelName,
     );
-    const overTunnelGroupKey = buildForwardTunnelGroupKey(overForward?.tunnelName);
+    const overTunnelGroupKey = buildForwardTunnelGroupKey(
+      overForward?.tunnelName,
+    );
 
     // 仅允许在同一用户+隧道分组内拖拽，避免混排
-    if (activeUserId !== overUserId || activeTunnelGroupKey !== overTunnelGroupKey) {
+    if (
+      activeUserId !== overUserId ||
+      activeTunnelGroupKey !== overTunnelGroupKey
+    ) {
       return;
     }
 
@@ -1672,13 +1683,7 @@ export default function ForwardPage() {
     }
 
     return sortedByDb;
-  }, [
-    forwards,
-    forwardOrder,
-    filterUserId,
-    filterTunnelId,
-    searchKeyword,
-  ]);
+  }, [forwards, forwardOrder, filterUserId, filterTunnelId, searchKeyword]);
 
   const groupedForwards = useMemo((): ForwardUserGroup[] => {
     if (orderedForwards.length === 0) {
@@ -1750,7 +1755,10 @@ export default function ForwardPage() {
           return aIsUncategorized ? 1 : -1;
         }
 
-        const nameCompare = compareForwardTunnelNameAsc(a.tunnelName, b.tunnelName);
+        const nameCompare = compareForwardTunnelNameAsc(
+          a.tunnelName,
+          b.tunnelName,
+        );
 
         if (nameCompare !== 0) {
           return nameCompare;
@@ -1838,6 +1846,7 @@ export default function ForwardPage() {
 
       if (!existingUser) {
         userMap.set(uId, { id: uId, name: userName });
+
         return;
       }
 
@@ -2663,10 +2672,14 @@ export default function ForwardPage() {
                                   </TableColumn>
                                 )}
                                 <TableColumn
-                                  className={FORWARD_GROUPED_TABLE_COLUMN_CLASS.drag}
+                                  className={
+                                    FORWARD_GROUPED_TABLE_COLUMN_CLASS.drag
+                                  }
                                 />
                                 <TableColumn
-                                  className={FORWARD_GROUPED_TABLE_COLUMN_CLASS.name}
+                                  className={
+                                    FORWARD_GROUPED_TABLE_COLUMN_CLASS.name
+                                  }
                                 >
                                   名称
                                 </TableColumn>
@@ -2678,7 +2691,9 @@ export default function ForwardPage() {
                                   入口
                                 </TableColumn>
                                 <TableColumn
-                                  className={FORWARD_GROUPED_TABLE_COLUMN_CLASS.target}
+                                  className={
+                                    FORWARD_GROUPED_TABLE_COLUMN_CLASS.target
+                                  }
                                 >
                                   目标
                                 </TableColumn>
@@ -2697,7 +2712,9 @@ export default function ForwardPage() {
                                   总流量
                                 </TableColumn>
                                 <TableColumn
-                                  className={FORWARD_GROUPED_TABLE_COLUMN_CLASS.status}
+                                  className={
+                                    FORWARD_GROUPED_TABLE_COLUMN_CLASS.status
+                                  }
                                 >
                                   状态
                                 </TableColumn>
@@ -2729,7 +2746,9 @@ export default function ForwardPage() {
                                       handleDiagnose={handleDiagnose}
                                       handleEdit={handleEdit}
                                       handleServiceToggle={handleServiceToggle}
-                                      hasMultipleAddresses={hasMultipleAddresses}
+                                      hasMultipleAddresses={
+                                        hasMultipleAddresses
+                                      }
                                       selectMode={selectMode}
                                       selectedIds={selectedIds}
                                       showAddressModal={showAddressModal}
@@ -2786,7 +2805,7 @@ export default function ForwardPage() {
                       <Chip color="primary" size="sm" variant="flat">
                         管理员本人
                       </Chip>
-                      )}
+                    )}
                   </div>
                   <span className="text-xs text-default-600">
                     {groupForwardCount} 条转发
@@ -2922,31 +2941,6 @@ export default function ForwardPage() {
                   </Select>
 
                   <Select
-                    description="transparent 为 UDP 源进源出模式"
-                    label="UDP 模式"
-                    placeholder="请选择 UDP 模式"
-                    selectedKeys={[form.udpMode]}
-                    variant="bordered"
-                    onSelectionChange={(keys) => {
-                      const selectedKey =
-                        (Array.from(keys)[0] as "normal" | "transparent" | undefined) ||
-                        "normal";
-
-                      setForm((prev) => ({
-                        ...prev,
-                        udpMode: selectedKey,
-                      }));
-                    }}
-                  >
-                    <SelectItem key="normal" textValue="normal">
-                      normal
-                    </SelectItem>
-                    <SelectItem key="transparent" textValue="transparent">
-                      transparent
-                    </SelectItem>
-                  </Select>
-
-                  <Select
                     description={
                       form.udpMode === "transparent"
                         ? "transparent 为 UDP 源进源出模式（高风险，依赖透明劫持与网络路径）"
@@ -2958,8 +2952,10 @@ export default function ForwardPage() {
                     variant="bordered"
                     onSelectionChange={(keys) => {
                       const selectedKey =
-                        (Array.from(keys)[0] as "normal" | "transparent" | undefined) ||
-                        "normal";
+                        (Array.from(keys)[0] as
+                          | "normal"
+                          | "transparent"
+                          | undefined) || "normal";
 
                       setForm((prev) => ({
                         ...prev,
@@ -3699,8 +3695,8 @@ export default function ForwardPage() {
                                           isDiagnosing
                                             ? "bg-warning-50 dark:bg-warning-900/20"
                                             : isSuccess
-                                            ? "bg-white dark:bg-gray-800"
-                                            : "bg-danger-50 dark:bg-danger-900/30"
+                                              ? "bg-white dark:bg-gray-800"
+                                              : "bg-danger-50 dark:bg-danger-900/30"
                                         }`}
                                       >
                                         <td className="px-3 py-2">
@@ -3735,8 +3731,8 @@ export default function ForwardPage() {
                                               isDiagnosing
                                                 ? "warning"
                                                 : isSuccess
-                                                ? "success"
-                                                : "danger"
+                                                  ? "success"
+                                                  : "danger"
                                             }
                                             size="sm"
                                             variant="flat"
@@ -3886,8 +3882,8 @@ export default function ForwardPage() {
                                       isDiagnosing
                                         ? "border-warning-200 dark:border-warning-300/30 bg-warning-50 dark:bg-warning-900/20"
                                         : isSuccess
-                                        ? "border-divider bg-white dark:bg-gray-800"
-                                        : "border-danger-200 dark:border-danger-300/30 bg-danger-50 dark:bg-danger-900/30"
+                                          ? "border-divider bg-white dark:bg-gray-800"
+                                          : "border-danger-200 dark:border-danger-300/30 bg-danger-50 dark:bg-danger-900/30"
                                     }`}
                                   >
                                     <div className="flex items-start gap-2 mb-2">

--- a/vite-frontend/src/pages/limit.tsx
+++ b/vite-frontend/src/pages/limit.tsx
@@ -195,6 +195,7 @@ export default function LimitPage() {
           speed: payload.speed,
           status: payload.status,
         };
+
         res = await createSpeedLimit(createData);
       }
 

--- a/vite-frontend/src/pages/tunnel.tsx
+++ b/vite-frontend/src/pages/tunnel.tsx
@@ -72,6 +72,20 @@ interface ChainTunnel {
   inx?: number; // 转发链序号
 }
 
+interface TunConfig {
+  net: string;
+  mtu?: number;
+  routes?: string;
+  dns?: string;
+  peer?: string;
+  gw?: string;
+  keepalive?: number;
+  ttl?: number;
+  passphrase?: string;
+  p2p?: boolean;
+  tunName?: string;
+}
+
 interface Tunnel {
   id: number;
   inx?: number;
@@ -86,6 +100,7 @@ interface Tunnel {
   flow: number; // 1: 单向, 2: 双向
   trafficRatio: number;
   ipPreference?: string;
+  tunConfig?: TunConfig;
   status: number;
   createdTime: string;
 }
@@ -107,6 +122,19 @@ interface TunnelForm {
   trafficRatio: number;
   inIp: string; // 入口IP
   ipPreference: string;
+  tunConfig: {
+    net: string;
+    mtu: number | null;
+    routes: string;
+    dns: string;
+    peer: string;
+    gw: string;
+    keepalive: number | null;
+    ttl: number | null;
+    passphrase: string;
+    p2p: boolean;
+    tunName: string;
+  };
   status: number;
 }
 
@@ -255,6 +283,19 @@ export default function TunnelPage() {
             .join("\n")
         : "",
       ipPreference: tunnel.ipPreference || "",
+      tunConfig: {
+        net: tunnel.tunConfig?.net || "",
+        mtu: tunnel.tunConfig?.mtu ?? 1420,
+        routes: normalizeListInput(tunnel.tunConfig?.routes),
+        dns: normalizeListInput(tunnel.tunConfig?.dns),
+        peer: normalizeListInput(tunnel.tunConfig?.peer),
+        gw: tunnel.tunConfig?.gw || "",
+        keepalive: tunnel.tunConfig?.keepalive ?? null,
+        ttl: tunnel.tunConfig?.ttl ?? null,
+        passphrase: tunnel.tunConfig?.passphrase || "",
+        p2p: tunnel.tunConfig?.p2p ?? false,
+        tunName: tunnel.tunConfig?.tunName || "",
+      },
       status: tunnel.status,
     });
     setErrors({});
@@ -313,6 +354,32 @@ export default function TunnelPage() {
     return Array.from(keys)
       .map((key) => Number.parseInt(String(key), 10))
       .filter((nodeId) => Number.isFinite(nodeId));
+  };
+
+  const normalizeListInput = (value: unknown): string => {
+    if (Array.isArray(value)) {
+      return value
+        .map((item) => String(item).trim())
+        .filter((item) => item)
+        .join("\n");
+    }
+    if (typeof value === "string") {
+      return value
+        .split(",")
+        .map((item) => item.trim())
+        .filter((item) => item)
+        .join("\n");
+    }
+
+    return "";
+  };
+
+  const toCommaList = (value: string): string => {
+    return value
+      .split("\n")
+      .map((item) => item.trim())
+      .filter((item) => item)
+      .join(",");
   };
 
   // 更新某一跳的所有节点的协议
@@ -428,6 +495,22 @@ export default function TunnelPage() {
         inIp: inIpString,
         outNodeId: cleanedOutNodeId,
         chainNodes: cleanedChainNodes,
+        tunConfig:
+          form.type === 3
+            ? {
+                net: form.tunConfig.net.trim(),
+                mtu: form.tunConfig.mtu || undefined,
+                routes: toCommaList(form.tunConfig.routes),
+                dns: toCommaList(form.tunConfig.dns),
+                peer: toCommaList(form.tunConfig.peer),
+                gw: form.tunConfig.gw.trim() || undefined,
+                keepalive: form.tunConfig.keepalive || undefined,
+                ttl: form.tunConfig.ttl || undefined,
+                passphrase: form.tunConfig.passphrase || undefined,
+                p2p: Boolean(form.tunConfig.p2p),
+                tunName: form.tunConfig.tunName.trim() || undefined,
+              }
+            : undefined,
       };
 
       const response = isEdit
@@ -452,6 +535,7 @@ export default function TunnelPage() {
   const handleDiagnose = async (tunnel: Tunnel) => {
     diagnosisAbortRef.current?.abort();
     const abortController = new AbortController();
+
     diagnosisAbortRef.current = abortController;
 
     setCurrentDiagnosisTunnel(tunnel);
@@ -500,6 +584,7 @@ export default function TunnelPage() {
             const startItems = Array.isArray(payload.items)
               ? (payload.items as DiagnosisResult["results"])
               : [];
+
             setDiagnosisResult((prev) => ({
               tunnelName: startTunnelName,
               tunnelType: startTunnelType,
@@ -546,6 +631,7 @@ export default function TunnelPage() {
                   diagnosing: false,
                 });
               }
+
               return {
                 ...base,
                 timestamp: Date.now(),
@@ -581,8 +667,11 @@ export default function TunnelPage() {
 
         if (response.code === 0) {
           const resultData = response.data as DiagnosisResult;
-          const successCount = resultData.results.filter((r) => r.success).length;
+          const successCount = resultData.results.filter(
+            (r) => r.success,
+          ).length;
           const failedCount = resultData.results.length - successCount;
+
           setDiagnosisResult(resultData);
           setDiagnosisProgress({
             total: resultData.results.length,
@@ -1100,7 +1189,7 @@ export default function TunnelPage() {
                                     />
                                   </svg>
                                   <span className="font-semibold text-secondary-700 dark:text-secondary-400">
-                                    {tunnel.type === 2
+                                    {tunnel.type !== 1
                                       ? tunnel.chainNodes?.length || 0
                                       : 0}
                                     跳
@@ -1138,7 +1227,7 @@ export default function TunnelPage() {
                                     />
                                   </svg>
                                   <span className="font-semibold text-success-700 dark:text-success-400">
-                                    {tunnel.type === 2
+                                    {tunnel.type !== 1
                                       ? tunnel.outNodeId?.length || 0
                                       : tunnel.inNodeId?.length || 0}
                                     出口
@@ -1149,7 +1238,7 @@ export default function TunnelPage() {
 
                             {/* 流量配置 */}
                             <div
-                              className={`grid gap-2 ${tunnel.type === 2 && tunnel.ipPreference ? "grid-cols-3" : "grid-cols-2"}`}
+                              className={`grid gap-2 ${tunnel.type !== 1 && tunnel.ipPreference ? "grid-cols-3" : "grid-cols-2"}`}
                             >
                               <div className="text-center p-1.5 bg-default-50 dark:bg-default-100/30 rounded">
                                 <div className="text-xs text-default-500">
@@ -1167,7 +1256,7 @@ export default function TunnelPage() {
                                   {tunnel.trafficRatio}x
                                 </div>
                               </div>
-                              {tunnel.type === 2 && tunnel.ipPreference && (
+                              {tunnel.type !== 1 && tunnel.ipPreference && (
                                 <div className="text-center p-1.5 bg-default-50 dark:bg-default-100/30 rounded">
                                   <div className="text-xs text-default-500">
                                     连接偏好
@@ -1180,6 +1269,46 @@ export default function TunnelPage() {
                                 </div>
                               )}
                             </div>
+
+                            {tunnel.type === 3 && tunnel.tunConfig && (
+                              <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mt-2">
+                                <div className="text-center p-1.5 bg-warning-50 dark:bg-warning-100/20 rounded">
+                                  <div className="text-xs text-default-500">
+                                    TUN 网段
+                                  </div>
+                                  <div className="text-sm font-semibold text-foreground mt-0.5 truncate">
+                                    {tunnel.tunConfig.net || "-"}
+                                  </div>
+                                </div>
+                                <div className="text-center p-1.5 bg-warning-50 dark:bg-warning-100/20 rounded">
+                                  <div className="text-xs text-default-500">
+                                    MTU
+                                  </div>
+                                  <div className="text-sm font-semibold text-foreground mt-0.5">
+                                    {tunnel.tunConfig.mtu || "-"}
+                                  </div>
+                                </div>
+                                <div className="text-center p-1.5 bg-warning-50 dark:bg-warning-100/20 rounded">
+                                  <div className="text-xs text-default-500">
+                                    Peer
+                                  </div>
+                                  <div className="text-sm font-semibold text-foreground mt-0.5">
+                                    {normalizeListInput(tunnel.tunConfig.peer)
+                                      .split("\n")
+                                      .filter((item) => item).length || 0}
+                                    个
+                                  </div>
+                                </div>
+                                <div className="text-center p-1.5 bg-warning-50 dark:bg-warning-100/20 rounded">
+                                  <div className="text-xs text-default-500">
+                                    P2P
+                                  </div>
+                                  <div className="text-sm font-semibold text-foreground mt-0.5">
+                                    {tunnel.tunConfig.p2p ? "开启" : "关闭"}
+                                  </div>
+                                </div>
+                              </div>
+                            )}
                           </div>
 
                           <div className="flex gap-1.5 mt-3">
@@ -1393,7 +1522,7 @@ export default function TunnelPage() {
                     }
                   />
 
-                  {form.type === 2 && (
+                  {form.type !== 1 && (
                     <Select
                       description="当节点同时拥有IPv4和IPv6地址时，选择隧道连接使用的地址类型"
                       label="隧道连接地址偏好"
@@ -1414,11 +1543,242 @@ export default function TunnelPage() {
                     </Select>
                   )}
 
+                  {form.type === 3 && (
+                    <>
+                      <Divider />
+                      <h3 className="text-lg font-semibold">TUN配置</h3>
+
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <Input
+                          description="必填，例如 10.10.0.0/24"
+                          errorMessage={errors.tunConfigNet}
+                          isInvalid={!!errors.tunConfigNet}
+                          label="网段 (net)"
+                          placeholder="10.10.0.0/24"
+                          value={form.tunConfig.net}
+                          variant="bordered"
+                          onChange={(e) =>
+                            setForm((prev) => ({
+                              ...prev,
+                              tunConfig: {
+                                ...prev.tunConfig,
+                                net: e.target.value,
+                              },
+                            }))
+                          }
+                        />
+                        <Input
+                          description="范围 576-9000"
+                          errorMessage={errors.tunConfigMtu}
+                          isInvalid={!!errors.tunConfigMtu}
+                          label="MTU"
+                          max={9000}
+                          min={576}
+                          placeholder="1420"
+                          type="number"
+                          value={
+                            form.tunConfig.mtu == null
+                              ? ""
+                              : String(form.tunConfig.mtu)
+                          }
+                          variant="bordered"
+                          onChange={(e) =>
+                            setForm((prev) => ({
+                              ...prev,
+                              tunConfig: {
+                                ...prev.tunConfig,
+                                mtu: e.target.value
+                                  ? Number.parseInt(e.target.value, 10)
+                                  : null,
+                              },
+                            }))
+                          }
+                        />
+                      </div>
+
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <Textarea
+                          description="每行一个路由网段"
+                          label="路由 (routes)"
+                          maxRows={4}
+                          minRows={2}
+                          placeholder="0.0.0.0/0"
+                          value={form.tunConfig.routes}
+                          variant="bordered"
+                          onChange={(e) =>
+                            setForm((prev) => ({
+                              ...prev,
+                              tunConfig: {
+                                ...prev.tunConfig,
+                                routes: e.target.value,
+                              },
+                            }))
+                          }
+                        />
+                        <Textarea
+                          description="每行一个 DNS 地址"
+                          label="DNS"
+                          maxRows={4}
+                          minRows={2}
+                          placeholder="8.8.8.8"
+                          value={form.tunConfig.dns}
+                          variant="bordered"
+                          onChange={(e) =>
+                            setForm((prev) => ({
+                              ...prev,
+                              tunConfig: {
+                                ...prev.tunConfig,
+                                dns: e.target.value,
+                              },
+                            }))
+                          }
+                        />
+                      </div>
+
+                      <Textarea
+                        description="每行一个 peer 地址，支持 ip:port"
+                        label="Peer"
+                        maxRows={4}
+                        minRows={2}
+                        placeholder="203.0.113.10:51820"
+                        value={form.tunConfig.peer}
+                        variant="bordered"
+                        onChange={(e) =>
+                          setForm((prev) => ({
+                            ...prev,
+                            tunConfig: {
+                              ...prev.tunConfig,
+                              peer: e.target.value,
+                            },
+                          }))
+                        }
+                      />
+
+                      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <Input
+                          label="网关 (gw)"
+                          placeholder="10.10.0.1"
+                          value={form.tunConfig.gw}
+                          variant="bordered"
+                          onChange={(e) =>
+                            setForm((prev) => ({
+                              ...prev,
+                              tunConfig: {
+                                ...prev.tunConfig,
+                                gw: e.target.value,
+                              },
+                            }))
+                          }
+                        />
+                        <Input
+                          label="保活 (keepalive)"
+                          min={0}
+                          placeholder="25"
+                          type="number"
+                          value={
+                            form.tunConfig.keepalive == null
+                              ? ""
+                              : String(form.tunConfig.keepalive)
+                          }
+                          variant="bordered"
+                          onChange={(e) =>
+                            setForm((prev) => ({
+                              ...prev,
+                              tunConfig: {
+                                ...prev.tunConfig,
+                                keepalive: e.target.value
+                                  ? Number.parseInt(e.target.value, 10)
+                                  : null,
+                              },
+                            }))
+                          }
+                        />
+                        <Input
+                          label="TTL"
+                          min={1}
+                          placeholder="64"
+                          type="number"
+                          value={
+                            form.tunConfig.ttl == null
+                              ? ""
+                              : String(form.tunConfig.ttl)
+                          }
+                          variant="bordered"
+                          onChange={(e) =>
+                            setForm((prev) => ({
+                              ...prev,
+                              tunConfig: {
+                                ...prev.tunConfig,
+                                ttl: e.target.value
+                                  ? Number.parseInt(e.target.value, 10)
+                                  : null,
+                              },
+                            }))
+                          }
+                        />
+                      </div>
+
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <Input
+                          label="TUN 名称 (tunName)"
+                          placeholder="tun0"
+                          value={form.tunConfig.tunName}
+                          variant="bordered"
+                          onChange={(e) =>
+                            setForm((prev) => ({
+                              ...prev,
+                              tunConfig: {
+                                ...prev.tunConfig,
+                                tunName: e.target.value,
+                              },
+                            }))
+                          }
+                        />
+                        <Input
+                          label="密钥短语 (passphrase)"
+                          placeholder="可选"
+                          type="password"
+                          value={form.tunConfig.passphrase}
+                          variant="bordered"
+                          onChange={(e) =>
+                            setForm((prev) => ({
+                              ...prev,
+                              tunConfig: {
+                                ...prev.tunConfig,
+                                passphrase: e.target.value,
+                              },
+                            }))
+                          }
+                        />
+                      </div>
+
+                      <Checkbox
+                        isSelected={form.tunConfig.p2p}
+                        onValueChange={(value) =>
+                          setForm((prev) => ({
+                            ...prev,
+                            tunConfig: {
+                              ...prev.tunConfig,
+                              p2p: value,
+                            },
+                          }))
+                        }
+                      >
+                        启用 P2P 模式
+                      </Checkbox>
+                    </>
+                  )}
+
                   <Divider />
                   <h3 className="text-lg font-semibold">入口配置</h3>
 
                   <div className="space-y-2">
                     <Select
+                      description={
+                        form.type === 3
+                          ? "TUN 模式要求单入口：请选择 1 个入口节点"
+                          : undefined
+                      }
                       disabledKeys={[
                         ...nodes
                           .filter((node) => node.status !== 1)
@@ -1431,11 +1791,15 @@ export default function TunnelPage() {
                       errorMessage={errors.inNodeId}
                       isInvalid={!!errors.inNodeId}
                       label="入口节点"
-                      placeholder="请选择入口节点（可多选）"
+                      placeholder={
+                        form.type === 3
+                          ? "请选择入口节点（仅 1 个）"
+                          : "请选择入口节点（可多选）"
+                      }
                       selectedKeys={form.inNodeId.map((ct) =>
                         ct.nodeId.toString(),
                       )}
-                      selectionMode="multiple"
+                      selectionMode={form.type === 3 ? "single" : "multiple"}
                       variant="bordered"
                       onSelectionChange={(keys) => {
                         const selectedIds = toSelectedNodeIds(keys);
@@ -1484,8 +1848,8 @@ export default function TunnelPage() {
                     </Select>
                   </div>
 
-                  {/* 隧道转发时显示转发链配置 */}
-                  {form.type === 2 && (
+                  {/* 链路型隧道时显示转发链配置 */}
+                  {form.type !== 1 && (
                     <>
                       <Divider />
                       <div className="flex items-center justify-between">
@@ -1770,8 +2134,8 @@ export default function TunnelPage() {
                     </>
                   )}
 
-                  {/* 隧道转发时显示出口配置 */}
-                  {form.type === 2 && (
+                  {/* 链路型隧道时显示出口配置 */}
+                  {form.type !== 1 && (
                     <>
                       <Divider />
                       <h3 className="text-lg font-semibold">出口配置</h3>
@@ -1784,6 +2148,11 @@ export default function TunnelPage() {
                               label: "text-xs",
                               value: "text-sm",
                             }}
+                            description={
+                              form.type === 3
+                                ? "TUN 模式要求单出口：请选择 1 个出口节点"
+                                : undefined
+                            }
                             disabledKeys={[
                               ...nodes
                                 .filter((node) => node.status !== 1)
@@ -1799,7 +2168,11 @@ export default function TunnelPage() {
                             errorMessage={errors.outNodeId}
                             isInvalid={!!errors.outNodeId}
                             label="节点"
-                            placeholder="请选择出口节点（可多选）"
+                            placeholder={
+                              form.type === 3
+                                ? "请选择出口节点（仅 1 个）"
+                                : "请选择出口节点（可多选）"
+                            }
                             selectedKeys={
                               form.outNodeId
                                 ? form.outNodeId
@@ -1807,7 +2180,9 @@ export default function TunnelPage() {
                                     .map((ct) => ct.nodeId.toString())
                                 : []
                             }
-                            selectionMode="multiple"
+                            selectionMode={
+                              form.type === 3 ? "single" : "multiple"
+                            }
                             variant="bordered"
                             onSelectionChange={(keys) => {
                               const selectedIds = toSelectedNodeIds(keys);
@@ -2281,8 +2656,8 @@ export default function TunnelPage() {
                                           isDiagnosing
                                             ? "bg-warning-50 dark:bg-warning-900/20"
                                             : isSuccess
-                                            ? "bg-white dark:bg-gray-800"
-                                            : "bg-danger-50 dark:bg-danger-900/30"
+                                              ? "bg-white dark:bg-gray-800"
+                                              : "bg-danger-50 dark:bg-danger-900/30"
                                         }`}
                                       >
                                         <td className="px-3 py-2">
@@ -2317,8 +2692,8 @@ export default function TunnelPage() {
                                               isDiagnosing
                                                 ? "warning"
                                                 : isSuccess
-                                                ? "success"
-                                                : "danger"
+                                                  ? "success"
+                                                  : "danger"
                                             }
                                             size="sm"
                                             variant="flat"
@@ -2467,8 +2842,8 @@ export default function TunnelPage() {
                                       isDiagnosing
                                         ? "border-warning-200 dark:border-warning-300/30 bg-warning-50 dark:bg-warning-900/20"
                                         : isSuccess
-                                        ? "border-divider bg-white dark:bg-gray-800"
-                                        : "border-danger-200 dark:border-danger-300/30 bg-danger-50 dark:bg-danger-900/30"
+                                          ? "border-divider bg-white dark:bg-gray-800"
+                                          : "border-danger-200 dark:border-danger-300/30 bg-danger-50 dark:bg-danger-900/30"
                                     }`}
                                   >
                                     <div className="flex items-start gap-2 mb-2">

--- a/vite-frontend/src/pages/tunnel/diagnosis.ts
+++ b/vite-frontend/src/pages/tunnel/diagnosis.ts
@@ -38,11 +38,7 @@ export const buildDiagnosisFallbackResult = ({
   return {
     tunnelName,
     tunnelType:
-      tunnelType === 1
-        ? "端口转发"
-        : tunnelType === 2
-          ? "隧道转发"
-          : "TUN隧道",
+      tunnelType === 1 ? "端口转发" : tunnelType === 2 ? "隧道转发" : "TUN隧道",
     timestamp: Date.now(),
     results: [
       {

--- a/vite-frontend/src/pages/tunnel/form.ts
+++ b/vite-frontend/src/pages/tunnel/form.ts
@@ -8,6 +8,10 @@ interface TunnelFormInput {
   inNodeId: TunnelChainNode[];
   outNodeId?: TunnelChainNode[];
   trafficRatio: number;
+  tunConfig?: {
+    net: string;
+    mtu: number | null;
+  };
 }
 
 interface TunnelNodeInput {
@@ -26,6 +30,19 @@ export const createTunnelFormDefaults = () => {
     trafficRatio: 1.0,
     inIp: "",
     ipPreference: "",
+    tunConfig: {
+      net: "",
+      mtu: 1420,
+      routes: "",
+      dns: "",
+      peer: "",
+      gw: "",
+      keepalive: null,
+      ttl: null,
+      passphrase: "",
+      p2p: false,
+      tunName: "",
+    },
     status: 1,
   };
 };
@@ -60,7 +77,7 @@ export const validateTunnelForm = (
     errors.trafficRatio = "流量倍率须大于0，支持小数（如 0.5）";
   }
 
-  if (form.type === 2) {
+  if (form.type !== 1) {
     if (!form.outNodeId || form.outNodeId.length === 0) {
       errors.outNodeId = "请至少选择一个出口节点";
     } else {
@@ -79,8 +96,26 @@ export const validateTunnelForm = (
       const overlap = inNodeIds.filter((id) => outNodeIds.includes(id));
 
       if (overlap.length > 0) {
-        errors.outNodeId = "隧道转发模式下，入口和出口不能有相同节点";
+        errors.outNodeId = "链路型隧道模式下，入口和出口不能有相同节点";
       }
+    }
+  }
+
+  if (form.type === 3) {
+    if (!form.tunConfig?.net?.trim()) {
+      errors.tunConfigNet = "TUN 配置的网段(net)不能为空";
+    }
+    if (
+      form.tunConfig?.mtu != null &&
+      (form.tunConfig.mtu < 576 || form.tunConfig.mtu > 9000)
+    ) {
+      errors.tunConfigMtu = "MTU 范围应为 576-9000";
+    }
+    if (!form.inNodeId || form.inNodeId.length !== 1) {
+      errors.inNodeId = "TUN 隧道要求单入口，入口节点数量必须为 1";
+    }
+    if (!form.outNodeId || form.outNodeId.length !== 1) {
+      errors.outNodeId = "TUN 隧道要求单出口，出口节点数量必须为 1";
     }
   }
 

--- a/vite-frontend/src/types/index.ts
+++ b/vite-frontend/src/types/index.ts
@@ -83,6 +83,19 @@ export interface Tunnel {
   exitNodeName?: string;
   status?: number;
   flow?: number; // 流量计算类型
+  tunConfig?: {
+    net?: string;
+    mtu?: number;
+    routes?: string | string[];
+    dns?: string | string[];
+    peer?: string | string[];
+    gw?: string;
+    keepalive?: number;
+    ttl?: number;
+    passphrase?: string;
+    p2p?: boolean;
+    tunName?: string;
+  };
 }
 
 export interface SpeedLimit {


### PR DESCRIPTION
## Summary

- Add TUN tunnel type (type=3) with single-entry single-exit topology validation
- Implement TUN configuration support with net, mtu, routes, dns, gateway, peer parameters
- Add buildChainRuntimeDiagnosisWorkItems and validateType3TunnelTopology for unified diagnostics
- Extend tunnel schema with tun_config column and migration to version 5
- Update frontend forms and API types to expose tunConfig for TUN tunnels
- Fix go-gost main.go Printf format strings for proper error logging
</parameter>