### PR TITLE
fix: prevent effect execution when forwards list is empty

### DIFF
--- a/vite-frontend/src/pages/forward.tsx
+++ b/vite-frontend/src/pages/forward.tsx
@@ -2505,6 +2505,10 @@ export default function ForwardPage() {
       return;
     }
 
+    if (forwards.length === 0) {
+      return;
+    }
+
     if (!isSameGroupOrderMap(groupOrderMap, sanitizedGroupOrderMap)) {
       setGroupOrderMap(sanitizedGroupOrderMap);
       persistGroupOrderToLocal(sanitizedGroupOrderMap);
@@ -2524,6 +2528,7 @@ export default function ForwardPage() {
   }, [
     groupPreferenceHydrated,
     tokenUserId,
+    forwards,
     groupOrderMap,
     sanitizedGroupOrderMap,
     collapsedTunnelGroups,


### PR DESCRIPTION
## Summary
- 添加空列表检查，防止在forwards为空时执行effect
- 避免不必要的groupOrder状态更新和持久化操作