### PR TITLE
style: restore Prettier formatting in renewal.ts

### DIFF
--- a/vite-frontend/src/pages/node/renewal.ts
+++ b/vite-frontend/src/pages/node/renewal.ts
@@ -14,6 +14,7 @@ const addMonths = (timestamp: number, months: number): number => {
   const next = new Date(date);
 
   next.setMonth(next.getMonth() + months);
+
   return next.getTime();
 };
 
@@ -72,7 +73,9 @@ export const getNodeRenewalSnapshot = (
     nextDueTime = advanced;
   }
 
-  const diffDays = Math.ceil((nextDueTime - Date.now()) / (1000 * 60 * 60 * 24));
+  const diffDays = Math.ceil(
+    (nextDueTime - Date.now()) / (1000 * 60 * 60 * 24),
+  );
 
   if (diffDays <= 0) {
     return {
@@ -110,5 +113,6 @@ export const formatNodeRenewalTime = (timestamp?: number): string => {
   if (!timestamp || timestamp <= 0) {
     return "未设置";
   }
+
   return new Date(timestamp).toLocaleString();
 };


### PR DESCRIPTION
## Summary
Restore Prettier formatting that was lost during merge conflict resolution in #297.

## Changes
- Add blank line after `setMonth` in `addMonths` function
- Format `diffDays` calculation with multi-line style
- Add blank line before return in `formatNodeRenewalTime`