### PR TITLE
fix(dialog): prevent auto focus restore on close to avoid page scroll

### DIFF
--- a/vite-frontend/src/components/ui/dialog.tsx
+++ b/vite-frontend/src/components/ui/dialog.tsx
@@ -61,6 +61,9 @@ function DialogContent({
           className,
         )}
         data-slot="dialog-content"
+        onCloseAutoFocus={(e) => {
+          e.preventDefault();
+        }}
         {...props}
       >
         {children}


### PR DESCRIPTION
## Summary
- 修复 Modal 关闭后页面滚动到顶部的问题
- 添加 `onCloseAutoFocus` 处理器阻止 Radix Dialog 自动恢复焦点到触发元素

## Details
当用户滚动页面后点击编辑按钮打开 Modal，关闭 Modal 时 Radix Dialog 会尝试将焦点恢复到编辑按钮。如果该按钮不在视口内，浏览器会自动滚动使焦点元素可见，导致页面跳到顶部。

通过 `e.preventDefault()` 阻止这一默认行为，保持页面当前滚动位置。