### PR TITLE
fix(dialog): prevent both open and close auto focus to avoid page scroll

### DIFF
--- a/vite-frontend/src/components/ui/dialog.tsx
+++ b/vite-frontend/src/components/ui/dialog.tsx
@@ -56,15 +56,18 @@ function DialogContent({
     <DialogPortal>
       <DialogOverlay />
       <DialogPrimitive.Content
+        {...props}
         className={cn(
           "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-default-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-bottom-4 data-[state=closed]:slide-out-to-bottom-2 sm:rounded-lg dark:bg-default-50",
           className,
         )}
         data-slot="dialog-content"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+        }}
         onCloseAutoFocus={(e) => {
           e.preventDefault();
         }}
-        {...props}
       >
         {children}
         {showCloseButton && (

--- a/vite-frontend/src/shadcn-bridge/heroui/modal.tsx
+++ b/vite-frontend/src/shadcn-bridge/heroui/modal.tsx
@@ -158,6 +158,9 @@ export function ModalContent({
         className,
       )}
       showCloseButton={false}
+      onOpenAutoFocus={(e) => {
+        e.preventDefault();
+      }}
       onCloseAutoFocus={(e) => {
         e.preventDefault();
       }}


### PR DESCRIPTION
## Summary
- 修复 Modal 关闭后页面滚动到顶部的问题
- 添加 `onOpenAutoFocus` 和 `onCloseAutoFocus` 处理器
- 将 `{...props}` 放在前面，确保焦点处理不会被覆盖

## Details
Radix Dialog 在打开和关闭时会自动管理焦点，这可能导致：
1. 打开时自动聚焦到内容
2. 关闭时恢复焦点到触发元素

这两个行为都可能导致页面滚动。通过 `e.preventDefault()` 阻止这些默认行为，保持页面当前滚动位置。

## 关键修改
- `dialog.tsx`: 添加 `onOpenAutoFocus` 处理，并将 `{...props}` 移到前面
- `modal.tsx`: 添加 `onOpenAutoFocus` 处理