### PR TITLE
fix: add missing renderCard prop to SortableForwardCard in non-compact card view

### DIFF
--- a/vite-frontend/src/pages/forward.tsx
+++ b/vite-frontend/src/pages/forward.tsx
@@ -4589,6 +4589,7 @@ export default function ForwardPage() {
                                       <SortableForwardCard
                                         key={forward.id}
                                         forward={forward}
+                                        renderCard={renderForwardCard}
                                       />
                                     ) : null,
                                   )}


### PR DESCRIPTION
## Summary
- Fix TypeError "renderCard is not a function" when using non-compact card view mode on the rules page
- The `SortableForwardCard` component was missing the required `renderCard` prop in the non-compact grouped view