### PR TITLE
fix(forward): make force-delete work with offline nodes

### DIFF
--- a/go-backend/internal/http/handler/mutations.go
+++ b/go-backend/internal/http/handler/mutations.go
@@ -1852,7 +1852,27 @@ func (h *Handler) forwardDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) forwardForceDelete(w http.ResponseWriter, r *http.Request) {
-	h.forwardDelete(w, r)
+	id := idFromBody(r, w)
+	if id <= 0 {
+		return
+	}
+	_, _, _, err := h.resolveForwardAccess(r, id)
+	if err != nil {
+		if errors.Is(err, errForwardNotFound) {
+			response.WriteJSON(w, response.ErrDefault("转发不存在"))
+			return
+		}
+		response.WriteJSON(w, response.Err(-2, err.Error()))
+		return
+	}
+
+	// Force delete: remove DB record without touching node services.
+	// This is used when nodes are offline or service deletion fails.
+	if err := h.deleteForwardByID(id); err != nil {
+		response.WriteJSON(w, response.Err(-2, err.Error()))
+		return
+	}
+	response.WriteJSON(w, response.OKEmpty())
 }
 
 func (h *Handler) forwardPause(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Fix `/forward/force-delete` to bypass `DeleteService` and delete the DB record directly after access checks.
- Prevent the UI from getting stuck in repeated delete/force-delete confirmation dialogs when some nodes are offline.

## Testing
- cd go-backend && go test ./internal/http/handler ./internal/store/repo