### PR TITLE
chore: release 2.1.9-rc7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 **Generated:** Tue Mar 24 2026
 **Commit:** 8ebde9d
 **Branch:** main
-**Tag:** 2.1.9-rc6
+**Tag:** 2.1.9-rc7
 
 ## OVERVIEW
 FLVX (formerly Flux Panel) is a traffic forwarding management system built on a forked GOST v3 stack. It ships as a Go-based admin API (SQLite/PostgreSQL) + Vite/React UI + Go forwarding agent, with optional mobile WebView wrappers.

--- a/plans/063-release-2-1-9-rc6.md
+++ b/plans/063-release-2-1-9-rc6.md
@@ -9,4 +9,4 @@ Sync all changes, bump version to `2.1.9-rc6`, create PR, merge, and publish tag
 - [x] Push branch to remote.
 - [x] Create Pull Request using `gh`.
 - [x] Merge Pull Request using `gh`.
-- [x] Create and push tag `v2.1.9-rc6`.
+- [x] Create and push tag `2.1.9-rc6`.

--- a/plans/064-release-2-1-9-rc7.md
+++ b/plans/064-release-2-1-9-rc7.md
@@ -1,0 +1,12 @@
+# Plan 064: Release 2.1.9-rc7
+
+Sync all changes, bump version to `2.1.9-rc7`, create PR, merge, and publish tag.
+
+## Tasks
+
+- [x] Update `AGENTS.md` with new tag (`2.1.9-rc7`) and today's date (`Tue Mar 24 2026`).
+- [ ] Commit all changes to branch `chore/rc7-bump`.
+- [ ] Push branch to remote.
+- [ ] Create Pull Request using `gh`.
+- [ ] Merge Pull Request using `gh`.
+- [ ] Create and push tag `2.1.9-rc7`.


### PR DESCRIPTION
Bump version to 2.1.9-rc7 in AGENTS.md