### PR TITLE
fix: resolve PostgreSQL type encoding issues for node metrics

### DIFF
--- a/go-backend/internal/store/repo/repository.go
+++ b/go-backend/internal/store/repo/repository.go
@@ -3349,20 +3349,20 @@ func (r *Repository) GetNodeMetrics(nodeID int64, startMs, endMs int64) ([]model
 		Select(
 			fmt.Sprintf(
 				"%d AS node_id, "+
-					"CAST(%s AS INTEGER) AS timestamp, "+
+					"CAST(%s AS BIGINT) AS timestamp, "+
 					"AVG(cpu_usage) AS cpu_usage, "+
 					"AVG(mem_usage) AS mem_usage, "+
 					"AVG(disk_usage) AS disk_usage, "+
-					"CAST(AVG(net_in_bytes) AS INTEGER) AS net_in_bytes, "+
-					"CAST(AVG(net_out_bytes) AS INTEGER) AS net_out_bytes, "+
-					"CAST(AVG(net_in_speed) AS INTEGER) AS net_in_speed, "+
-					"CAST(AVG(net_out_speed) AS INTEGER) AS net_out_speed, "+
+					"CAST(AVG(net_in_bytes) AS BIGINT) AS net_in_bytes, "+
+					"CAST(AVG(net_out_bytes) AS BIGINT) AS net_out_bytes, "+
+					"CAST(AVG(net_in_speed) AS BIGINT) AS net_in_speed, "+
+					"CAST(AVG(net_out_speed) AS BIGINT) AS net_out_speed, "+
 					"AVG(load1) AS load1, "+
 					"AVG(load5) AS load5, "+
 					"AVG(load15) AS load15, "+
-					"CAST(AVG(tcp_conns) AS INTEGER) AS tcp_conns, "+
-					"CAST(AVG(udp_conns) AS INTEGER) AS udp_conns, "+
-					"CAST(MAX(uptime) AS INTEGER) AS uptime",
+					"CAST(AVG(tcp_conns) AS BIGINT) AS tcp_conns, "+
+					"CAST(AVG(udp_conns) AS BIGINT) AS udp_conns, "+
+					"CAST(MAX(uptime) AS BIGINT) AS uptime",
 				nodeID, bucketExpr,
 			),
 		).

--- a/plans/065-fix-node-metrics-postgres-type.md
+++ b/plans/065-fix-node-metrics-postgres-type.md
@@ -1,0 +1,11 @@
+# Fix Node Metrics PostgreSQL Type Encoding
+
+## Objective
+Fix the PostgreSQL type encoding error (`failed to encode args[0]: unable to encode 5 into text format for text (OID 25)`) and `integer out of range` error when querying node metrics for time ranges greater than 1 hour.
+
+## Tasks
+- [x] Identify the problematic downsampled SQL aggregation in `GetNodeMetrics`.
+- [x] Fix the `? AS node_id` placeholder which confused PostgreSQL's type inference by directly embedding the `nodeID` using `fmt.Sprintf("%d AS node_id")`.
+- [x] Change all `CAST(X AS INTEGER)` to `CAST(X AS BIGINT)` to prevent 32-bit integer overflow on Unix millisecond timestamps in PostgreSQL.
+- [x] Verify the build and tests pass.
+- [ ] Commit all changes, create a new branch, push, create a Pull Request, merge the PR into `main`, and publish a new tag `2.1.9-rc9`.


### PR DESCRIPTION
Fixed OID 25 (text) inference failing to encode int64 by embedding the node ID format string directly. Replaced CAST(x AS INTEGER) with CAST(x AS BIGINT) to prevent 32-bit overflow on Unix milliseconds timestamps.