### PR TITLE
fix(backend): include interfaceName in ListNodes API response

### DIFF
--- a/go-backend/internal/store/repo/repository.go
+++ b/go-backend/internal/store/repo/repository.go
@@ -683,6 +683,7 @@ func (r *Repository) ListNodes() ([]map[string]interface{}, error) {
 			"remoteToken":               nullableString(n.RemoteToken),
 			"remoteConfig":              nullableString(n.RemoteConfig),
 			"expiryReminderDismissed":   n.ExpiryReminderDismissed,
+			"interfaceName":             nullableString(n.InterfaceName),
 		})
 	}
 	return items, nil


### PR DESCRIPTION
使用的时候发现“高级设置”中的 出口IP 功能不正常 故使用 Opus 4.6 简单检查并修复了一下
- - -
Root Cause Identified ✅
The bug is in the backend API response, not the frontend or database save logic.
The Problem
When you enter "eth2" in the node settings "出口网卡名或IP" field:
1. ✅ Frontend saves correctly → handleSubmit sends interfaceName: "eth2" to API
2. ✅ Backend stores correctly → nodeCreate/nodeUpdate save to database as InterfaceName
3. ❌ Backend API doesn't return it → ListNodes method omits interfaceName from response
4. ❌ Frontend receives empty value → Form shows blank after refresh
- - - 
- Add missing interfaceName field to node list API response map
- Fixes bug where interface name value disappears after page refresh
- Field is correctly saved to DB but was not returned in API response