### PR TITLE
chore: TCP ping now uses configured interface for accurate testing

### DIFF
--- a/go-backend/internal/http/client/federation.go
+++ b/go-backend/internal/http/client/federation.go
@@ -71,10 +71,11 @@ type RuntimeReleaseRoleRequest struct {
 }
 
 type RuntimeDiagnoseRequest struct {
-	IP      string `json:"ip"`
-	Port    int    `json:"port"`
-	Count   int    `json:"count"`
-	Timeout int    `json:"timeout"`
+	IP        string `json:"ip"`
+	Port      int    `json:"port"`
+	Count     int    `json:"count"`
+	Timeout   int    `json:"timeout"`
+	Interface string `json:"interface,omitempty"`
 }
 
 type RuntimeNodeCommandRequest struct {

--- a/go-backend/internal/http/handler/control_plane.go
+++ b/go-backend/internal/http/handler/control_plane.go
@@ -1261,7 +1261,7 @@ func (h *Handler) appendPathDiagnosis(results *[]map[string]interface{}, nodeCac
 	if fromNode.IsRemote == 1 {
 		pingData, pingErr = h.tcpPingViaRemoteNode(fromNode, targetIP, targetPort, options)
 	} else {
-		pingData, pingErr = h.tcpPingViaNode(fromNodeID, targetIP, targetPort, options)
+		pingData, pingErr = h.tcpPingViaNode(fromNode, targetIP, targetPort, options)
 	}
 	if pingErr != nil {
 		item["success"] = false
@@ -1357,19 +1357,26 @@ func (h *Handler) listChainNodesForTunnel(tunnelID int64) ([]chainNodeRecord, er
 	return h.repo.ListChainNodesForTunnel(tunnelID)
 }
 
-func (h *Handler) tcpPingViaNode(nodeID int64, ip string, port int, options diagnosisExecOptions) (map[string]interface{}, error) {
+func (h *Handler) tcpPingViaNode(node *nodeRecord, ip string, port int, options diagnosisExecOptions) (map[string]interface{}, error) {
+	if node == nil {
+		return nil, errors.New("节点不存在")
+	}
 	if options.commandTimeout <= 0 {
 		options.commandTimeout = diagnosisCommandTimeout
 	}
 	if options.pingTimeoutMS <= 0 {
 		options.pingTimeoutMS = int(diagnosisCommandTimeout / time.Millisecond)
 	}
-	res, err := h.sendNodeCommandWithTimeout(nodeID, "TcpPing", map[string]interface{}{
+	cmdData := map[string]interface{}{
 		"ip":      ip,
 		"port":    port,
 		"count":   4,
 		"timeout": options.pingTimeoutMS,
-	}, options.commandTimeout, false, false)
+	}
+	if ifaceName := strings.TrimSpace(node.InterfaceName); ifaceName != "" {
+		cmdData["interface"] = ifaceName
+	}
+	res, err := h.sendNodeCommandWithTimeout(node.ID, "TcpPing", cmdData, options.commandTimeout, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1397,10 +1404,11 @@ func (h *Handler) tcpPingViaRemoteNode(node *nodeRecord, ip string, port int, op
 
 	fc := client.NewFederationClientWithTimeout(options.commandTimeout)
 	return fc.Diagnose(remoteURL, remoteToken, h.federationLocalDomain(), client.RuntimeDiagnoseRequest{
-		IP:      strings.TrimSpace(ip),
-		Port:    port,
-		Count:   4,
-		Timeout: options.pingTimeoutMS,
+		IP:        strings.TrimSpace(ip),
+		Port:      port,
+		Count:     4,
+		Timeout:   options.pingTimeoutMS,
+		Interface: strings.TrimSpace(node.InterfaceName),
 	})
 }
 

--- a/go-backend/internal/http/handler/federation.go
+++ b/go-backend/internal/http/handler/federation.go
@@ -85,10 +85,11 @@ type federationRuntimeReleaseRoleRequest struct {
 }
 
 type federationRuntimeDiagnoseRequest struct {
-	IP      string `json:"ip"`
-	Port    int    `json:"port"`
-	Count   int    `json:"count"`
-	Timeout int    `json:"timeout"`
+	IP        string `json:"ip"`
+	Port      int    `json:"port"`
+	Count     int    `json:"count"`
+	Timeout   int    `json:"timeout"`
+	Interface string `json:"interface,omitempty"`
 }
 
 type federationRuntimeCommandRequest struct {
@@ -1257,12 +1258,16 @@ func (h *Handler) federationRuntimeDiagnose(w http.ResponseWriter, r *http.Reque
 		commandTimeout = diagnosisCommandTimeout
 	}
 
-	res, err := h.sendNodeCommandWithTimeout(share.NodeID, "TcpPing", map[string]interface{}{
+	cmdData := map[string]interface{}{
 		"ip":      req.IP,
 		"port":    req.Port,
 		"count":   req.Count,
 		"timeout": req.Timeout,
-	}, commandTimeout, false, false)
+	}
+	if ifaceName := strings.TrimSpace(req.Interface); ifaceName != "" {
+		cmdData["interface"] = ifaceName
+	}
+	res, err := h.sendNodeCommandWithTimeout(share.NodeID, "TcpPing", cmdData, commandTimeout, false, false)
 	if err != nil {
 		response.WriteJSON(w, response.ErrDefault(err.Error()))
 		return

--- a/go-backend/internal/http/handler/tunnel_quality_prober.go
+++ b/go-backend/internal/http/handler/tunnel_quality_prober.go
@@ -384,7 +384,7 @@ func (p *tunnelQualityProber) tcpPingNode(nodeID int64, ip string, port int, opt
 	if node != nil && node.IsRemote == 1 {
 		pingData, pingErr = h.tcpPingViaRemoteNode(node, ip, port, options)
 	} else {
-		pingData, pingErr = h.tcpPingViaNode(nodeID, ip, port, options)
+		pingData, pingErr = h.tcpPingViaNode(node, ip, port, options)
 	}
 	if pingErr != nil {
 		return 0, 100, pingErr

--- a/go-backend/internal/store/repo/repository.go
+++ b/go-backend/internal/store/repo/repository.go
@@ -683,6 +683,7 @@ func (r *Repository) ListNodes() ([]map[string]interface{}, error) {
 			"remoteToken":               nullableString(n.RemoteToken),
 			"remoteConfig":              nullableString(n.RemoteConfig),
 			"expiryReminderDismissed":   n.ExpiryReminderDismissed,
+			"interfaceName":             nullableString(n.InterfaceName),
 		})
 	}
 	return items, nil

--- a/go-gost/x/socket/websocket_reporter.go
+++ b/go-gost/x/socket/websocket_reporter.go
@@ -111,6 +111,7 @@ type TcpPingRequest struct {
 	Port      int    `json:"port"`
 	Count     int    `json:"count"`
 	Timeout   int    `json:"timeout"` // 超时时间(毫秒)
+	Interface string `json:"interface,omitempty"` // 指定出口网络接口名称
 	RequestId string `json:"requestId,omitempty"`
 }
 
@@ -1652,8 +1653,7 @@ func (w *WebSocketReporter) handleTcpPing(data interface{}) (TcpPingResponse, er
 		req.Timeout = 5000 // 默认5秒超时
 	}
 
-	// 执行TCP ping操作
-	avgTime, packetLoss, err := tcpPingHost(req.IP, req.Port, req.Count, req.Timeout)
+	avgTime, packetLoss, err := tcpPingHost(req.IP, req.Port, req.Count, req.Timeout, req.Interface)
 
 	response := TcpPingResponse{
 		IP:        req.IP,
@@ -1877,22 +1877,43 @@ func icmpPing(target string, timeout time.Duration) (time.Duration, error) {
 	}
 }
 
-// tcpPingHost 执行TCP连接测试，返回平均连接时间和失败率
-func tcpPingHost(ip string, port int, count int, timeoutMs int) (float64, float64, error) {
+func tcpPingHost(ip string, port int, count int, timeoutMs int, ifaceName string) (float64, float64, error) {
 	var totalTime float64
 	var successCount int
 
 	timeout := time.Duration(timeoutMs) * time.Millisecond
-
-	// 使用net.JoinHostPort来正确处理IPv4、IPv6和域名
-	// 它会自动为IPv6地址添加方括号
 	target := net.JoinHostPort(ip, fmt.Sprintf("%d", port))
 
-	fmt.Printf("🔍 开始TCP ping测试: %s，次数: %d，超时: %dms\n", target, count, timeoutMs)
+	var localAddr net.Addr
+	if ifaceName != "" {
+		ife, err := net.InterfaceByName(ifaceName)
+		if err != nil {
+			return 0, 100.0, fmt.Errorf("获取网络接口 %s 失败: %v", ifaceName, err)
+		}
+		addrs, err := ife.Addrs()
+		if err != nil {
+			return 0, 100.0, fmt.Errorf("获取接口 %s 地址失败: %v", ifaceName, err)
+		}
+		if len(addrs) == 0 {
+			return 0, 100.0, fmt.Errorf("接口 %s 没有可用地址", ifaceName)
+		}
+		for _, addr := range addrs {
+			if ipNet, ok := addr.(*net.IPNet); ok && ipNet.IP.To4() != nil {
+				localAddr = &net.TCPAddr{IP: ipNet.IP, Port: 0}
+				break
+			}
+		}
+		if localAddr == nil {
+			if ipNet, ok := addrs[0].(*net.IPNet); ok {
+				localAddr = &net.TCPAddr{IP: ipNet.IP, Port: 0}
+			}
+		}
+		fmt.Printf("🔍 开始TCP ping测试: %s，次数: %d，超时: %dms，出口接口: %s (%v)\n", target, count, timeoutMs, ifaceName, localAddr)
+	} else {
+		fmt.Printf("🔍 开始TCP ping测试: %s，次数: %d，超时: %dms\n", target, count, timeoutMs)
+	}
 
-	// 如果是域名，先解析一次DNS，避免每次连接都重新解析导致延迟累加
 	if net.ParseIP(ip) == nil {
-		// 是域名，需要解析
 		fmt.Printf("🔍 检测到域名，正在解析DNS...\n")
 		dnsStart := time.Now()
 
@@ -1909,18 +1930,21 @@ func tcpPingHost(ip string, port int, count int, timeoutMs int) (float64, float6
 		fmt.Printf("✅ DNS解析完成 (%.2fms)，解析到 %d 个IP: %v\n",
 			dnsDuration.Seconds()*1000, len(addrs), addrs)
 
-		// 使用第一个解析到的IP进行测试
 		target = net.JoinHostPort(addrs[0], fmt.Sprintf("%d", port))
 		fmt.Printf("🎯 使用IP地址进行测试: %s\n", target)
 	} else {
 		fmt.Printf("🎯 使用IP地址进行测试: %s\n", target)
 	}
 
+	dialer := &net.Dialer{
+		Timeout:   timeout,
+		LocalAddr: localAddr,
+	}
+
 	for i := 0; i < count; i++ {
 		start := time.Now()
 
-		// 创建带超时的TCP连接
-		conn, err := net.DialTimeout("tcp", target, timeout)
+		conn, err := dialer.Dial("tcp", target)
 
 		elapsed := time.Since(start)
 
@@ -1929,11 +1953,10 @@ func tcpPingHost(ip string, port int, count int, timeoutMs int) (float64, float6
 		} else {
 			fmt.Printf("  第%d次连接成功: %.2fms\n", i+1, elapsed.Seconds()*1000)
 			conn.Close()
-			totalTime += elapsed.Seconds() * 1000 // 转换为毫秒
+			totalTime += elapsed.Seconds() * 1000
 			successCount++
 		}
 
-		// 如果不是最后一次，等待一下再进行下次测试
 		if i < count-1 {
 			time.Sleep(100 * time.Millisecond)
 		}


### PR DESCRIPTION
**现象**：之前的误解是由于——即使配置了 `eth2` 作为出口接口，面板转发页面的"测试"按钮仍使用默认网络路径进行 TCP ping。
**根因**：`TcpPing` 命令不支持接口绑定参数。
- `TcpPingRequest` 结构体无 `interface` 字段
- `tcpPingHost` 函数使用 `net.DialTimeout` 直连，无法指定本地地址
- 后端 `tcpPingViaNode` 未读取节点的 `interfaceName` 配置
- - -
Temped Solution:
Agent 端 (go-gost/x/socket/websocket_reporter.go):
- TcpPingRequest 添加 Interface 字段
- tcpPingHost 改用 net.Dialer + LocalAddr 绑定接口 IP
Backend 端:
- tcpPingViaNode 从 node.InterfaceName 读取配置并传递
- tcpPingViaRemoteNode 支持 Federation 场景
- Federation diagnose 请求添加 interface 字段
- - -
📊 Data Flow (After Fix)
Panel 测试按钮
    ↓
tcpPingViaNode(node, ip, port)
    ↓ 读取 node.InterfaceName = "eth2"
TcpPing { ip, port, interface: "eth2" }
    ↓ WebSocket
Agent handleTcpPing
    ↓ net.InterfaceByName("eth2")
    ↓ 获取接口 IP
net.Dialer{ LocalAddr: 192.168.1.100:0 }
    ↓
dialer.Dial("tcp", target) ← 使用指定接口出口

