### PR TITLE
fix(agent): add port cleanup before resuming paused services

### DIFF
--- a/go-gost/x/api/config_service.go
+++ b/go-gost/x/api/config_service.go
@@ -624,6 +624,11 @@ func resumeService(ctx *gin.Context) {
 	existingSvc.Close()
 	registry.ServiceRegistry().Unregister(name)
 
+	// 强制断开端口的所有连接
+	if serviceConfig.Addr != "" {
+		_ = kill.ForceClosePortConnections(serviceConfig.Addr)
+	}
+
 	// 等待端口释放
 	time.Sleep(500 * time.Millisecond)
 
@@ -1039,8 +1044,13 @@ func resumeServices(ctx *gin.Context) {
 		str.service.Close()
 		registry.ServiceRegistry().Unregister(str.name)
 
+		// 强制断开端口的所有连接
+		if str.serviceConfig.Addr != "" {
+			_ = kill.ForceClosePortConnections(str.serviceConfig.Addr)
+		}
+
 		// 等待端口释放
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(500 * time.Millisecond)
 
 		// 重新解析并启动服务
 		svc, err := parser.ParseService(str.serviceConfig)

--- a/go-gost/x/socket/service.go
+++ b/go-gost/x/socket/service.go
@@ -397,8 +397,13 @@ func resumeServices(req resumeServicesRequest) error {
 		str.service.Close()
 		registry.ServiceRegistry().Unregister(str.name)
 
+		// 强制断开端口的所有连接
+		if str.serviceConfig.Addr != "" {
+			_ = kill.ForceClosePortConnections(str.serviceConfig.Addr)
+		}
+
 		// 等待端口释放
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(500 * time.Millisecond)
 
 		// 重新解析并启动服务
 		svc, err := parser.ParseService(str.serviceConfig)


### PR DESCRIPTION
## Summary
- Fix issue #387: 用户流量达标后重置流量无法启用节点，提示端口已被占用
- 在 `resumeServices` 和 `resumeService` 函数中添加 `ForceClosePortConnections` 调用
- 将等待时间从 100ms 增加到 500ms 以确保端口完全释放

## Problem
当用户流量达到限制后，节点会被自动暂停（调用 `ForceClosePortConnections` 清理端口连接）。管理员手动重置用户流量后，尝试重新启用节点时失败，提示「节点端口已被使用」。

## Root Cause
`pauseServices` 在暂停服务时调用 `ForceClosePortConnections` 清理端口连接，但 `resumeServices` 在恢复服务时**缺少端口清理逻辑**，且只等待 100ms，不足以让端口完全释放。

## Changes
- `go-gost/x/socket/service.go:resumeServices` - 添加端口清理 + 增加等待时间到 500ms
- `go-gost/x/api/config_service.go:resumeService` - 添加端口清理
- `go-gost/x/api/config_service.go:resumeServices` - 添加端口清理 + 增加等待时间到 500ms

## Test Plan
- ✅ `go test ./tests/contract/...` quota 相关测试通过
- ✅ `go build ./socket && go build ./api` 编译成功

Fixes #387