### PR TITLE
feat: show license expiry date when commercial license is activated

### DIFF
--- a/go-backend/internal/http/handler/handler.go
+++ b/go-backend/internal/http/handler/handler.go
@@ -871,6 +871,15 @@ func (h *Handler) licenseActivate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	expiry := valResp.Data.Attributes.Expiry
+	if expiry == "" {
+		expiry = "never"
+	}
+	if err := h.repo.UpsertConfig("license_expiry", expiry, now); err != nil {
+		response.WriteJSON(w, response.Err(-2, err.Error()))
+		return
+	}
+
 	response.WriteJSON(w, response.OKEmpty())
 }
 

--- a/go-backend/internal/http/handler/jobs.go
+++ b/go-backend/internal/http/handler/jobs.go
@@ -74,6 +74,13 @@ func (h *Handler) validateLicenseJob() {
 		// License is invalid (e.g., revoked, suspended, expired). Downgrade the system.
 		now := time.Now().UnixMilli()
 		_ = h.repo.UpsertConfig("is_commercial", "false", now)
+	} else {
+		now := time.Now().UnixMilli()
+		expiry := valResp.Data.Attributes.Expiry
+		if expiry == "" {
+			expiry = "never"
+		}
+		_ = h.repo.UpsertConfig("license_expiry", expiry, now)
 	}
 }
 

--- a/go-backend/internal/license/keygen.go
+++ b/go-backend/internal/license/keygen.go
@@ -30,7 +30,10 @@ type ValidateResponse struct {
 		Code  string `json:"code"`
 	} `json:"meta"`
 	Data struct {
-		ID string `json:"id"`
+		ID         string `json:"id"`
+		Attributes struct {
+			Expiry string `json:"expiry"`
+		} `json:"attributes"`
 	} `json:"data"`
 }
 

--- a/vite-frontend/src/pages/config.tsx
+++ b/vite-frontend/src/pages/config.tsx
@@ -981,7 +981,7 @@ export default function ConfigPage() {
               variant="bordered"
               onChange={(e) => setLicenseKeyInput(e.target.value)}
               isDisabled={configs.is_commercial === "true"}
-              description={configs.is_commercial === "true" ? "已激活商业版授权" : "需商业授权才能修改站名、图标并隐藏页脚品牌"}
+              description={configs.is_commercial === "true" ? (configs.license_expiry && configs.license_expiry !== "never" ? `已激活商业版授权 (有效期至: ${new Date(configs.license_expiry).toLocaleDateString()})` : "已激活商业版授权 (永久有效)") : "需商业授权才能修改站名、图标并隐藏页脚品牌"}
             />
             <Button
               color="primary"


### PR DESCRIPTION
## Summary
- Extracted the `expiry` attribute from Keygen's `ValidateResponse`.
- Updated `licenseActivate` and `validateLicenseJob` to store `license_expiry` in the database.
- Read `license_expiry` into the frontend `siteConfig` map.
- Updated the description in the commercial license input to dynamically show the expiry date: '已激活商业版授权 (有效期至: YYYY-MM-DD)' or '已激活商业版授权 (永久有效)' if it doesn't expire.