### PR TITLE
feat: inject keygen account id via action secret during build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -233,6 +233,7 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --push \
+            --build-arg KEYGEN_ACCOUNT_ID=${{ secrets.KEYGEN_ACCOUNT_ID }} \
             -t ${{ env.REGISTRY }}/${OWNER}/flux-panel-backend:latest \
             -t ${{ env.REGISTRY }}/${OWNER}/flux-panel-backend:${VERSION} \
             ./go-backend

--- a/go-backend/Dockerfile
+++ b/go-backend/Dockerfile
@@ -7,7 +7,8 @@ RUN go mod download
 COPY . .
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} env ${TARGETARCH:+GOARCH=${TARGETARCH}} go build -o /out/paneld ./cmd/paneld
+ARG KEYGEN_ACCOUNT_ID
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} env ${TARGETARCH:+GOARCH=${TARGETARCH}} go build -ldflags="-X 'go-backend/internal/license.AccountID=${KEYGEN_ACCOUNT_ID}'" -o /out/paneld ./cmd/paneld
 
 FROM debian:bookworm-slim
 WORKDIR /app

--- a/go-backend/internal/http/handler/handler.go
+++ b/go-backend/internal/http/handler/handler.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -854,7 +855,10 @@ func (h *Handler) licenseActivate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	accountID := "1bc96cac-09de-4cf4-af34-26afdad63a90"
+	accountID := license.AccountID
+	if accountID == "" {
+		accountID = os.Getenv("KEYGEN_ACCOUNT_ID")
+	}
 
 	fingerprint, err := h.getOrCreateMachineFingerprint()
 	if err != nil {

--- a/go-backend/internal/http/handler/jobs.go
+++ b/go-backend/internal/http/handler/jobs.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"go-backend/internal/license"
@@ -52,7 +53,10 @@ func (h *Handler) validateLicenseJob() {
 		return
 	}
 
-	accountID := "1bc96cac-09de-4cf4-af34-26afdad63a90"
+	accountID := license.AccountID
+	if accountID == "" {
+		accountID = os.Getenv("KEYGEN_ACCOUNT_ID")
+	}
 
 	key, _ := h.repo.GetViteConfigValue("license_key")
 	isCommercial, _ := h.repo.GetViteConfigValue("is_commercial")

--- a/go-backend/internal/license/keygen.go
+++ b/go-backend/internal/license/keygen.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+var AccountID = ""
+
 type KeygenClient struct {
 	AccountID  string
 	Token      string


### PR DESCRIPTION
Removes hardcoded KEYGEN_ACCOUNT_ID and dynamically injects it during CI Docker build.