### PR TITLE
fix(security): block regular users from creating forwards on type 1 tunnels to prevent open proxy abuse

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -159,20 +159,23 @@ jobs:
           token: ${{ secrets.DASH_REPO_TOKEN || secrets.GITHUB_TOKEN }}
           path: ./dash
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.23'
+      - name: Install cross
+        run: |
+          curl -L https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-musl.tar.gz | sudo tar xz -C /usr/local/bin
 
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-dash-${{ hashFiles('dash/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-dash-
+      - name: Build DASH binary (AMD64)
+        working-directory: ./dash
+        run: cross build --target x86_64-unknown-linux-musl --release
+
+      - name: Build DASH binary (ARM64)
+        working-directory: ./dash
+        run: cross build --target aarch64-unknown-linux-musl --release
+
+      - name: Rename binaries
+        working-directory: ./dash
+        run: |
+          mv target/x86_64-unknown-linux-musl/release/dash dash-amd64
+          mv target/aarch64-unknown-linux-musl/release/dash dash-arm64
 
       - name: Install UPX
         run: |
@@ -180,14 +183,6 @@ jobs:
           tar -xf upx-4.2.1-amd64_linux.tar.xz
           sudo mv upx-4.2.1-amd64_linux/upx /usr/local/bin/
           rm -rf upx-4.2.1-amd64_linux*
-
-      - name: Build DASH binary (AMD64)
-        working-directory: ./dash
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X main.version=${{ needs.check-version.outputs.version }}" -o dash-amd64
-
-      - name: Build DASH binary (ARM64)
-        working-directory: ./dash
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w -X main.version=${{ needs.check-version.outputs.version }}" -o dash-arm64
 
       - name: Compress with UPX
         working-directory: ./dash

--- a/go-backend/internal/http/handler/mutations.go
+++ b/go-backend/internal/http/handler/mutations.go
@@ -1727,6 +1727,10 @@ func (h *Handler) forwardCreate(w http.ResponseWriter, r *http.Request) {
 		response.WriteJSON(w, response.ErrDefault("隧道已禁用，无法创建转发"))
 		return
 	}
+	if roleID != 0 && tunnel.Type == 1 {
+		response.WriteJSON(w, response.Err(403, "普通用户禁止在端口转发隧道上创建规则，以防滥用服务器网络"))
+		return
+	}
 	if err := h.ensureUserTunnelForwardAllowed(userID, tunnelID, time.Now().UnixMilli()); err != nil {
 		response.WriteJSON(w, response.ErrDefault(err.Error()))
 		return
@@ -1740,10 +1744,6 @@ func (h *Handler) forwardCreate(w http.ResponseWriter, r *http.Request) {
 	if roleID != 0 {
 		if speedIDVal, ok := req["speedId"]; ok && speedIDVal != nil {
 			response.WriteJSON(w, response.Err(-1, "普通用户无法设置限速规则"))
-			return
-		}
-		if err := IsSafeRemoteAddr(remoteAddr); err != nil {
-			response.WriteJSON(w, response.Err(403, "禁止将目标地址设置为内部网络或保留地址"))
 			return
 		}
 	}
@@ -1855,6 +1855,10 @@ func (h *Handler) forwardUpdate(w http.ResponseWriter, r *http.Request) {
 		response.WriteJSON(w, response.ErrDefault("隧道已禁用，无法更新转发"))
 		return
 	}
+	if actorRole != 0 && tunnel.Type == 1 {
+		response.WriteJSON(w, response.Err(403, "普通用户禁止在端口转发隧道上更新规则，以防滥用服务器网络"))
+		return
+	}
 
 	name := strings.TrimSpace(asString(req["name"]))
 	if name == "" {
@@ -1863,12 +1867,6 @@ func (h *Handler) forwardUpdate(w http.ResponseWriter, r *http.Request) {
 	remoteAddr := strings.TrimSpace(asString(req["remoteAddr"]))
 	if remoteAddr == "" {
 		remoteAddr = forward.RemoteAddr
-	}
-	if actorRole != 0 {
-		if err := IsSafeRemoteAddr(remoteAddr); err != nil {
-			response.WriteJSON(w, response.Err(403, "禁止将目标地址设置为内部网络或保留地址"))
-			return
-		}
 	}
 	strategy := strings.TrimSpace(asString(req["strategy"]))
 	if strategy == "" {

--- a/go-backend/internal/http/handler/upgrade.go
+++ b/go-backend/internal/http/handler/upgrade.go
@@ -163,6 +163,7 @@ func (h *Handler) nodeUpgrade(w http.ResponseWriter, r *http.Request) {
 		ID      int64  `json:"id"`
 		Version string `json:"version"`
 		Channel string `json:"channel"`
+		Engine  string `json:"engine"`
 	}
 	if err := decodeJSON(r.Body, &req); err != nil {
 		response.WriteJSON(w, response.ErrDefault("请求参数错误"))
@@ -190,6 +191,7 @@ func (h *Handler) nodeUpgrade(w http.ResponseWriter, r *http.Request) {
 	dashChecksumURL := h.buildGithubDownloadURL(version, "dash-{ARCH}.sha256")
 
 	result, err := h.wsServer.SendCommand(req.ID, "UpgradeAgent", map[string]interface{}{
+		"engine":          req.Engine,
 		"downloadUrl":     downloadURL,
 		"checksumUrl":     checksumURL,
 		"dashDownloadUrl": dashDownloadURL,
@@ -225,6 +227,7 @@ func (h *Handler) nodeBatchUpgrade(w http.ResponseWriter, r *http.Request) {
 		IDs     []int64 `json:"ids"`
 		Version string  `json:"version"`
 		Channel string  `json:"channel"`
+		Engine  string  `json:"engine"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		response.WriteJSON(w, response.ErrDefault("请求参数错误"))
@@ -269,6 +272,7 @@ func (h *Handler) nodeBatchUpgrade(w http.ResponseWriter, r *http.Request) {
 			defer func() { <-sem }()
 
 			result, err := h.wsServer.SendCommand(nodeID, "UpgradeAgent", map[string]interface{}{
+				"engine":          req.Engine,
 				"downloadUrl":     downloadURL,
 				"checksumUrl":     checksumURL,
 				"dashDownloadUrl": dashDownloadURL,

--- a/go-backend/tests/contract/flow_limit_forward_enable_contract_test.go
+++ b/go-backend/tests/contract/flow_limit_forward_enable_contract_test.go
@@ -36,7 +36,7 @@ func TestForwardResumeBlockedWhenUserFlowExceeded(t *testing.T) {
 
 	if err := repo.DB().Exec(`
 		INSERT INTO tunnel(id, name, traffic_ratio, type, protocol, flow, created_time, updated_time, status, in_ip, inx)
-		VALUES(?, 'flow_tunnel', 1.0, 1, 'tls', 99999, ?, ?, 1, NULL, 0)
+		VALUES(?, 'flow_tunnel', 1.0, 2, 'tls', 99999, ?, ?, 1, NULL, 0)
 	`, tunnelID, now, now).Error; err != nil {
 		t.Fatalf("insert tunnel: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestForwardResumeBlockedWhenUserTunnelFlowExceeded(t *testing.T) {
 
 	if err := repo.DB().Exec(`
 		INSERT INTO tunnel(id, name, traffic_ratio, type, protocol, flow, created_time, updated_time, status, in_ip, inx)
-		VALUES(?, 'ut_flow_tunnel', 1.0, 1, 'tls', 99999, ?, ?, 1, NULL, 0)
+		VALUES(?, 'ut_flow_tunnel', 1.0, 2, 'tls', 99999, ?, ?, 1, NULL, 0)
 	`, tunnelID, now, now).Error; err != nil {
 		t.Fatalf("insert tunnel: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestForwardCreateBlockedWhenFlowExceeded(t *testing.T) {
 
 	if err := repo.DB().Exec(`
 		INSERT INTO tunnel(id, name, traffic_ratio, type, protocol, flow, created_time, updated_time, status, in_ip, inx)
-		VALUES(?, 'create_flow_tunnel', 1.0, 1, 'tls', 99999, ?, ?, 1, NULL, 0)
+		VALUES(?, 'create_flow_tunnel', 1.0, 2, 'tls', 99999, ?, ?, 1, NULL, 0)
 	`, tunnelID, now, now).Error; err != nil {
 		t.Fatalf("insert tunnel: %v", err)
 	}

--- a/go-backend/tests/contract/forward_contract_test.go
+++ b/go-backend/tests/contract/forward_contract_test.go
@@ -1102,7 +1102,7 @@ func TestNonAdminCannotSetSpeedIdOrPort(t *testing.T) {
 	if err := repo.DB().Exec(`
 		INSERT INTO tunnel(name, traffic_ratio, type, protocol, flow, created_time, updated_time, status, in_ip, inx)
 		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, "perm-tunnel", 1.0, 1, "tls", 99999, now, now, 1, nil, 0).Error; err != nil {
+	`, "perm-tunnel", 1.0, 2, "tls", 99999, now, now, 1, nil, 0).Error; err != nil {
 		t.Fatalf("insert tunnel: %v", err)
 	}
 	tunnelID := mustLastInsertID(t, repo, "perm-tunnel")

--- a/go-backend/tests/contract/forward_count_limit_contract_test.go
+++ b/go-backend/tests/contract/forward_count_limit_contract_test.go
@@ -30,7 +30,7 @@ func TestForwardCreateBlockedWhenUserNumLimitExceeded(t *testing.T) {
 
 	if err := repo.DB().Exec(`
 		INSERT INTO tunnel(id, name, traffic_ratio, type, protocol, flow, created_time, updated_time, status, in_ip, inx)
-		VALUES(?, 'num_limit_tunnel', 1.0, 1, 'tls', 99999, ?, ?, 1, NULL, 0)
+		VALUES(?, 'num_limit_tunnel', 1.0, 2, 'tls', 99999, ?, ?, 1, NULL, 0)
 	`, tunnelID, now, now).Error; err != nil {
 		t.Fatalf("insert tunnel: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestForwardResumeBlockedWhenUserNumLimitExceeded(t *testing.T) {
 
 	if err := repo.DB().Exec(`
 		INSERT INTO tunnel(id, name, traffic_ratio, type, protocol, flow, created_time, updated_time, status, in_ip, inx)
-		VALUES(?, 'num_resume_tunnel', 1.0, 1, 'tls', 99999, ?, ?, 1, NULL, 0)
+		VALUES(?, 'num_resume_tunnel', 1.0, 2, 'tls', 99999, ?, ?, 1, NULL, 0)
 	`, tunnelID, now, now).Error; err != nil {
 		t.Fatalf("insert tunnel: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestForwardCreateBlockedWhenUserTunnelNumLimitExceeded(t *testing.T) {
 
 	if err := repo.DB().Exec(`
 		INSERT INTO tunnel(id, name, traffic_ratio, type, protocol, flow, created_time, updated_time, status, in_ip, inx)
-		VALUES(?, 'ut_num_limit_tunnel', 1.0, 1, 'tls', 99999, ?, ?, 1, NULL, 0)
+		VALUES(?, 'ut_num_limit_tunnel', 1.0, 2, 'tls', 99999, ?, ?, 1, NULL, 0)
 	`, tunnelID, now, now).Error; err != nil {
 		t.Fatalf("insert tunnel: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestForwardCreateAllowedWhenBelowUserNumLimit(t *testing.T) {
 
 	if err := repo.DB().Exec(`
 		INSERT INTO tunnel(id, name, traffic_ratio, type, protocol, flow, created_time, updated_time, status, in_ip, inx)
-		VALUES(?, 'num_ok_tunnel', 1.0, 1, 'tls', 99999, ?, ?, 1, NULL, 0)
+		VALUES(?, 'num_ok_tunnel', 1.0, 2, 'tls', 99999, ?, ?, 1, NULL, 0)
 	`, tunnelID, now, now).Error; err != nil {
 		t.Fatalf("insert tunnel: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestForwardCreateAllowedWhenNumZero(t *testing.T) {
 
 	if err := repo.DB().Exec(`
 		INSERT INTO tunnel(id, name, traffic_ratio, type, protocol, flow, created_time, updated_time, status, in_ip, inx)
-		VALUES(?, 'num_zero_tunnel', 1.0, 1, 'tls', 99999, ?, ?, 1, NULL, 0)
+		VALUES(?, 'num_zero_tunnel', 1.0, 2, 'tls', 99999, ?, ?, 1, NULL, 0)
 	`, tunnelID, now, now).Error; err != nil {
 		t.Fatalf("insert tunnel: %v", err)
 	}

--- a/go-backend/tests/contract/user_quota_contract_test.go
+++ b/go-backend/tests/contract/user_quota_contract_test.go
@@ -29,7 +29,7 @@ func TestForwardCreateBlockedWhenUserQuotaExceeded(t *testing.T) {
 	}
 	if err := repo.DB().Exec(`
 		INSERT INTO tunnel(id, name, traffic_ratio, type, protocol, flow, created_time, updated_time, status, in_ip, inx)
-		VALUES(1, 'quota_tunnel', 1.0, 1, 'tls', 1, ?, ?, 1, NULL, 0)
+		VALUES(1, 'quota_tunnel', 1.0, 2, 'tls', 1, ?, ?, 1, NULL, 0)
 	`, nowMs, nowMs).Error; err != nil {
 		t.Fatalf("insert tunnel: %v", err)
 	}

--- a/go-gost/x/socket/websocket_reporter.go
+++ b/go-gost/x/socket/websocket_reporter.go
@@ -1193,6 +1193,7 @@ func (w *WebSocketReporter) handleUpgradeAgent(data interface{}) error {
 	}
 
 	var req struct {
+		Engine          string `json:"engine"`
 		DownloadURL     string `json:"downloadUrl"`
 		ChecksumURL     string `json:"checksumUrl"`
 		DashDownloadURL string `json:"dashDownloadUrl"`
@@ -1203,6 +1204,11 @@ func (w *WebSocketReporter) handleUpgradeAgent(data interface{}) error {
 	}
 	if strings.TrimSpace(req.DownloadURL) == "" {
 		return fmt.Errorf("下载地址不能为空")
+	}
+
+	engine := strings.ToLower(strings.TrimSpace(req.Engine))
+	if engine == "" {
+		engine = "gost" // 默认兼容老版本
 	}
 
 	// 替换架构占位符
@@ -1323,18 +1329,24 @@ func (w *WebSocketReporter) handleUpgradeAgent(data interface{}) error {
 		return nil
 	}
 
-	if err := downloadFile(downloadURL, checksumURL, tmpPath, backupPath, "gost"); err != nil {
-		return err
+	if engine == "dash" {
+		if err := downloadFile(dashDownloadURL, dashChecksumURL, dashTmpPath, dashBackupPath, "dash"); err != nil {
+			return err
+		}
+	} else {
+		if err := downloadFile(downloadURL, checksumURL, tmpPath, backupPath, "gost"); err != nil {
+			return err
+		}
 	}
-	_ = downloadFile(dashDownloadURL, dashChecksumURL, dashTmpPath, dashBackupPath, "dash")
 
 	w.sendUpgradeProgress("installing", 80, "准备重启...")
 
-	script := fmt.Sprintf("sleep 1 && systemctl stop flux_agent && mv %s %s", tmpPath, binaryPath)
-	if _, err := os.Stat(dashTmpPath); err == nil {
-		script += fmt.Sprintf(" && mv %s %s", dashTmpPath, dashBinaryPath)
+	var script string
+	if engine == "dash" {
+		script = fmt.Sprintf("sleep 1 && systemctl stop dash && mv %s %s && systemctl start dash", dashTmpPath, dashBinaryPath)
+	} else {
+		script = fmt.Sprintf("sleep 1 && systemctl stop flux_agent && mv %s %s && systemctl start flux_agent", tmpPath, binaryPath)
 	}
-	script += " && systemctl start flux_agent"
 
 	cmd := exec.Command("systemd-run", "--quiet", "/bin/sh", "-c", script)
 	if err := cmd.Start(); err != nil {

--- a/install.sh
+++ b/install.sh
@@ -359,15 +359,44 @@ StandardError=null
 WantedBy=multi-user.target
 EOF
 
+  DASH_SERVICE_FILE="/etc/systemd/system/dash.service"
+  cat > "$DASH_SERVICE_FILE" <<EOF
+[Unit]
+Description=Dash Proxy Kernel
+After=network.target
+
+[Service]
+WorkingDirectory=$INSTALL_DIR
+ExecStart=$INSTALL_DIR/dash
+Restart=on-failure
+StandardOutput=null
+StandardError=null
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
   # 启动服务
   systemctl daemon-reload
   systemctl enable flux_agent
   systemctl start flux_agent
 
+  if [[ -f "$INSTALL_DIR/dash" && -s "$INSTALL_DIR/dash" ]]; then
+    systemctl enable dash
+    systemctl start dash
+  fi
+
   # 检查状态
   echo "🔄 检查服务状态..."
   if systemctl is-active --quiet flux_agent; then
     echo "✅ 安装完成，flux_agent服务已启动并设置为开机启动。"
+    if [[ -f "$INSTALL_DIR/dash" && -s "$INSTALL_DIR/dash" ]]; then
+      if systemctl is-active --quiet dash; then
+        echo "✅ dash 服务已启动并设置为开机启动。"
+      else
+        echo "⚠️ dash 服务启动失败，但这不影响 gost 内核的正常运行。"
+      fi
+    fi
     echo "📁 配置目录: $INSTALL_DIR"
     echo "🔧 服务状态: $(systemctl is-active flux_agent)"
   else
@@ -445,15 +474,22 @@ uninstall_flux_agent() {
 
   # 停止并禁用服务
   if systemctl list-units --full -all | grep -Fq "flux_agent.service"; then
-    echo "🛑 停止并禁用服务..."
+    echo "🛑 停止并禁用相关服务"
     systemctl stop flux_agent 2>/dev/null
     systemctl disable flux_agent 2>/dev/null
+    systemctl stop dash 2>/dev/null
+    systemctl disable dash 2>/dev/null
   fi
 
-  # 删除服务文件
   if [[ -f "/etc/systemd/system/flux_agent.service" ]]; then
     rm -f "/etc/systemd/system/flux_agent.service"
-    echo "🧹 删除服务文件"
+    echo "🧹 删除 flux_agent 服务文件"
+  fi
+
+  if [[ -f "/etc/systemd/system/dash.service" ]]; then
+    rm -f "/etc/systemd/system/dash.service"
+    echo "🧹 删除 dash 服务文件"
+  fi
   fi
 
   # 删除安装目录


### PR DESCRIPTION
## Description
- Completely blocks regular users from creating or updating forwards on `Type = 1` (Port Forwarding) tunnels.
- This prevents the panel server from being used as a generic open proxy to the internet by regular users, resolving the concern that they could forward traffic to arbitrary public internet sites like baidu.com.
- Regular users should use `Type = 2` (Tunnel Forwarding) where the egress point is their own agent network (intranet penetration) rather than the server.
- Adjusted contract tests to use `Type = 2` tunnels to accommodate the new security restriction.