### PR TITLE
fix: disable actions/setup-go cache to avoid go.sum path error

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -83,6 +83,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+          cache: false
 
       - name: Cache Go modules
         uses: actions/cache@v4
@@ -276,6 +277,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+          cache: false
 
       - name: Cache Go dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
Disables actions/setup-go builtin cache to prevent go.sum path not found error.