### PR TITLE
fix: update CI and Dockerfile to go 1.25

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache-dependency-path: go-backend/go.sum
 
       - name: Download dependencies
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache-dependency-path: go-backend/go.sum
 
       - name: Download dependencies
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache-dependency-path: go-gost/go.sum
 
       - name: Download dependencies

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -161,8 +161,7 @@ jobs:
           path: ./dash
 
       - name: Install cross
-        run: |
-          curl -L https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-musl.tar.gz | sudo tar xz -C /usr/local/bin
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build DASH binary (AMD64)
         working-directory: ./dash

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache: false
 
       - name: Cache Go modules
@@ -275,7 +275,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache: false
 
       - name: Cache Go dependencies

--- a/go-backend/Dockerfile
+++ b/go-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 WORKDIR /src
 
 COPY go.mod go.sum ./


### PR DESCRIPTION
Dependencies were updated to go 1.25 recently which broke the CI builds using 1.23/1.24.