### PR TITLE
fix: enable DASH_RUNTIME_ENABLED in docker-compose templates

### DIFF
--- a/docker-compose-v4.yml
+++ b/docker-compose-v4.yml
@@ -15,6 +15,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       SERVER_ADDR: :6365
       TZ: Asia/Shanghai
+      DASH_RUNTIME_ENABLED: "1"
     ports:
       - "${BACKEND_PORT}:6365"
     volumes:

--- a/docker-compose-v6.yml
+++ b/docker-compose-v6.yml
@@ -15,6 +15,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       SERVER_ADDR: :6365
       TZ: Asia/Shanghai
+      DASH_RUNTIME_ENABLED: "1"
     ports:
       - "${BACKEND_PORT}:6365"
     volumes:

--- a/install.sh
+++ b/install.sh
@@ -454,7 +454,6 @@ uninstall_flux_agent() {
     rm -f "/etc/systemd/system/flux_agent.service"
     echo "🧹 删除服务文件"
   fi
-  fi
 
   # 删除安装目录
   if [[ -d "$INSTALL_DIR" ]]; then


### PR DESCRIPTION
Sets DASH_RUNTIME_ENABLED: 1 by default so users can seamlessly switch to the dash engine.