### PR TITLE
fix(dash): handle ipv6 listen socket address parsing and implement active rule deletion

### DIFF
--- a/go-backend/internal/dashruntime/mapper.go
+++ b/go-backend/internal/dashruntime/mapper.go
@@ -2,6 +2,8 @@ package dashruntime
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 
 	"go-backend/internal/store/model"
@@ -96,7 +98,7 @@ func buildForwardRulePayload(
 	return RelayRulePayload{
 		ID:          ruleID,
 		Protocol:    protocol,
-		Listen:      fmt.Sprintf("%s:%d", listenHost, port.Port),
+		Listen:      net.JoinHostPort(listenHost, strconv.Itoa(port.Port)),
 		Enabled:     true,
 		Description: &description,
 		StagePools:  stagePools,

--- a/go-backend/internal/http/handler/mutations.go
+++ b/go-backend/internal/http/handler/mutations.go
@@ -724,9 +724,20 @@ func (h *Handler) cleanupTunnelRuntime(tunnelID int64) {
 	if err != nil || tunnel.Type != 2 {
 		return
 	}
+	
 	chainRows, err := h.listChainNodesForTunnel(tunnelID)
 	if err != nil {
 		return
+	}
+
+	if client, err := h.currentRuntimeClient(); err == nil {
+		if deleter, ok := client.(dashRuleDeleter); ok {
+			for _, row := range chainRows {
+				if row.ChainType == 3 {
+					_ = deleter.DeleteRule(context.Background(), row.NodeID, fmt.Sprintf("tunnel-%d", tunnelID))
+				}
+			}
+		}
 	}
 
 	serviceName := fmt.Sprintf("%d_tls", tunnelID)
@@ -3903,6 +3914,11 @@ func (h *Handler) deleteTunnelByID(id int64) error {
 }
 
 func (h *Handler) deleteForwardByID(id int64) error {
+	forward, err := h.getForwardRecord(id)
+	if err == nil {
+		oldPorts, _ := h.listForwardPorts(id)
+		_ = h.reconcileForwardRuntimeForCurrentEngine(context.Background(), id, forward.TunnelID, oldPorts, nil, nil)
+	}
 	return h.repo.DeleteForwardCascade(id)
 }
 


### PR DESCRIPTION
- Fix 'invalid listen socket address: :::51317' caused by improperly stripped IPv6 bracket notation by using net.JoinHostPort for Dash rule generation.

- Trigger dash API rule deletion correctly when tunnels and forward rules are destroyed via the panel to prevent lingering memory state.
