### PR TITLE
fix: automatically sync current runtime engine to nodes upon connection

### DIFF
--- a/go-backend/internal/http/handler/upgrade.go
+++ b/go-backend/internal/http/handler/upgrade.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -401,6 +402,13 @@ func (h *Handler) consumeNodePendingUpgradeRedeploy(nodeID int64) bool {
 }
 
 func (h *Handler) onNodeOnline(nodeID int64) {
+	// Sync global runtime engine to the newly connected node
+	if client, err := h.currentRuntimeClient(); err == nil {
+		if node, err := h.repo.GetNodeByID(nodeID); err == nil && node != nil {
+			go client.EnsureNodeRuntime(context.Background(), *node)
+		}
+	}
+
 	if !h.consumeNodePendingUpgradeRedeploy(nodeID) {
 		return
 	}

--- a/go-gost/x/socket/engine_handler.go
+++ b/go-gost/x/socket/engine_handler.go
@@ -33,6 +33,11 @@ func (w *WebSocketReporter) handleSetEngine(data interface{}) error {
 	} else {
 		cfg = make(map[string]interface{})
 	}
+
+	if currentEngine, ok := cfg["engine"].(string); ok && currentEngine == engine {
+		return nil
+	}
+
 	cfg["engine"] = engine
 
 	newData, _ := json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
This ensures nodes have the engine field populated in their config and are running the correct kernel if they are restarted or a user switches the engine.