### PR TITLE
fix(dash): adapt to latest dash CLI parameters and unified config

### DIFF
--- a/go-gost/x/socket/config.go
+++ b/go-gost/x/socket/config.go
@@ -43,29 +43,6 @@ func saveConfig() error {
 
 	cfg := config.Global()
 
-	// Ensure API service is present for Dash REST API
-	if isDashRuntime() {
-		apiFound := false
-		for _, s := range cfg.Services {
-			if s.Name == "api" {
-				apiFound = true
-				break
-			}
-		}
-		if !apiFound {
-			cfg.Services = append(cfg.Services, &config.ServiceConfig{
-				Name: "api",
-				Addr: "127.0.0.1:19090",
-				Handler: &config.HandlerConfig{
-					Type: "auto",
-				},
-				Listener: &config.ListenerConfig{
-					Type: "tcp",
-				},
-			})
-		}
-	}
-
 	f, err := os.Create(file)
 	if err != nil {
 		return err

--- a/go-gost/x/socket/dash_manager.go
+++ b/go-gost/x/socket/dash_manager.go
@@ -44,8 +44,8 @@ func StartDashSupervisor(ctx context.Context) {
 						dashCancel = cancel
 						dashMu.Unlock()
 
-						// Launch dash using the unified gost.json config
-						cmd := exec.CommandContext(ctxDash, dashPath, "-C", "gost.json")
+						// Launch dash using the unified gost.json config and explicit API flag
+						cmd := exec.CommandContext(ctxDash, dashPath, "-C", "gost.json", "--api", "127.0.0.1:19090")
 						cmd.Stdout = os.Stdout
 						cmd.Stderr = os.Stderr
 						fmt.Println("🚀 启动 dash 内核进程 (由 flux_agent 托管)...")


### PR DESCRIPTION
This PR removes deprecated --mode flag, uses the new --api flag, and unifies on a standard gost.json without custom injections.