### PR TITLE
fix(dash): ensure services is not null in gost.json

### DIFF
--- a/go-gost/x/socket/config.go
+++ b/go-gost/x/socket/config.go
@@ -43,6 +43,35 @@ func saveConfig() error {
 
 	cfg := config.Global()
 
+	// Ensure Services is at least an empty slice, not nil, to avoid "services": null in JSON
+	if cfg.Services == nil {
+		cfg.Services = []*config.ServiceConfig{}
+	}
+
+	// Ensure API service is present for Dash if in dash mode
+	// Dash requires at least one service to start via config file
+	if isDashRuntime() {
+		apiFound := false
+		for _, s := range cfg.Services {
+			if s.Name == "api" {
+				apiFound = true
+				break
+			}
+		}
+		if !apiFound {
+			cfg.Services = append(cfg.Services, &config.ServiceConfig{
+				Name: "api",
+				Addr: "127.0.0.1:19090",
+				Handler: &config.HandlerConfig{
+					Type: "auto",
+				},
+				Listener: &config.ListenerConfig{
+					Type: "tcp",
+				},
+			})
+		}
+	}
+
 	f, err := os.Create(file)
 	if err != nil {
 		return err


### PR DESCRIPTION
This fix prevents Dash from crashing on startup when the configuration file has a null services field, and ensures the API service is always present in Dash mode.