### PR TITLE
fix(dash): move api to CLI and ensure valid gost.json

### DIFF
--- a/go-gost/x/socket/config.go
+++ b/go-gost/x/socket/config.go
@@ -43,44 +43,25 @@ func saveConfig() error {
 
 	cfg := config.Global()
 
-	// Ensure Services is at least an empty slice, not nil, to avoid "services": null in JSON
-	if cfg.Services == nil {
-		cfg.Services = []*config.ServiceConfig{}
+	// Use a map to ensure we have full control over the JSON structure
+	// and specifically avoid "services": null
+	services := cfg.Services
+	if services == nil {
+		services = []*config.ServiceConfig{}
 	}
 
-	// Ensure API service is present for Dash if in dash mode
-	// Dash requires at least one service to start via config file
-	if isDashRuntime() {
-		apiFound := false
-		for _, s := range cfg.Services {
-			if s.Name == "api" {
-				apiFound = true
-				break
-			}
-		}
-		if !apiFound {
-			cfg.Services = append(cfg.Services, &config.ServiceConfig{
-				Name: "api",
-				Addr: "127.0.0.1:19090",
-				Handler: &config.HandlerConfig{
-					Type: "auto",
-				},
-				Listener: &config.ListenerConfig{
-					Type: "tcp",
-				},
-			})
-		}
+	data := map[string]interface{}{
+		"services": services,
+		"chains":   cfg.Chains,
+		"authers":  cfg.Authers,
+		"limiters": cfg.Limiters,
+		"api":      cfg.API,
 	}
 
-	f, err := os.Create(file)
+	jsonData, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
-	if err := cfg.Write(f, "json"); err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(file, jsonData, 0644)
 }

--- a/go-gost/x/socket/dash_manager.go
+++ b/go-gost/x/socket/dash_manager.go
@@ -44,8 +44,8 @@ func StartDashSupervisor(ctx context.Context) {
 						dashCancel = cancel
 						dashMu.Unlock()
 
-						// Launch dash using the unified gost.json config and explicit API flag
-						cmd := exec.CommandContext(ctxDash, dashPath, "-C", "gost.json", "--api", "127.0.0.1:19090")
+						// Launch dash using the unified gost.json config and dynamic API listener via -L
+						cmd := exec.CommandContext(ctxDash, dashPath, "-C", "gost.json", "-L", "tcp://127.0.0.1:19090?handler=auto")
 						cmd.Stdout = os.Stdout
 						cmd.Stderr = os.Stderr
 						fmt.Println("🚀 启动 dash 内核进程 (由 flux_agent 托管)...")


### PR DESCRIPTION
This PR ensures gost.json always has a non-null services list and moves the API listener to a CLI flag to keep the configuration file clean.