### PR TITLE
fix: properly initialize maxConn in forward rules

### DIFF
--- a/vite-frontend/src/pages/forward.tsx
+++ b/vite-frontend/src/pages/forward.tsx
@@ -2115,6 +2115,7 @@ export default function ForwardPage() {
       interfaceName: forward.interfaceName || "",
       strategy: forward.strategy || "fifo",
       speedId: normalizeSpeedId(forward.speedId),
+      maxConn: forward.maxConn || 0,
     });
     setErrors({});
     setModalOpen(true);

--- a/vite-frontend/src/pages/forward.tsx
+++ b/vite-frontend/src/pages/forward.tsx
@@ -118,6 +118,7 @@ interface Forward {
   outFlow: number;
   serviceRunning: boolean;
   federationShareFlow?: number;
+  maxConn?: number;
   createdTime: string;
   userName?: string;
   userId?: number;


### PR DESCRIPTION
## Summary
- Ensure that `maxConn` is initialized in both `handleAdd` and `handleEdit` form resets. This resolves the issue where the UI would drop or fail to display the existing configured maximum connection count for a rule.