### PR TITLE
fix: ensure page refresh to login page upon logout

### DIFF
--- a/vite-frontend/src/utils/logout.ts
+++ b/vite-frontend/src/utils/logout.ts
@@ -2,8 +2,9 @@ import { clearSession } from "@/utils/session";
 
 /**
  * 安全退出登录函数
- * 清除登录相关数据，但保留用户偏好设置（如主题）
+ * 清除登录相关数据，并强制刷新跳转到首页
  */
 export const safeLogout = () => {
   clearSession();
+  window.location.href = "/";
 };


### PR DESCRIPTION
## Summary
- Add `window.location.href = '/'` to `safeLogout()` to enforce a full page reload when navigating back to the login page.
- Resolves an issue where single-page application state might persist and the URL stays on the dashboard/inner panels instead of refreshing properly to the login view.