### PR TITLE
fix: remove duplicate maxConn input in user form

### DIFF
--- a/vite-frontend/src/pages/user.tsx
+++ b/vite-frontend/src/pages/user.tsx
@@ -1530,17 +1530,6 @@ export default function UserPage() {
                 }}
               />
               <Input
-                label="最大连接数"
-                placeholder="0 或空表示不限制"
-                type="number"
-                min="0"
-                value={userForm.maxConn === 0 ? "" : String(userForm.maxConn || "")}
-                onChange={(e) => {
-                  const value = Math.max(Number(e.target.value) || 0, 0);
-                  setUserForm((prev) => ({ ...prev, maxConn: value }));
-                }}
-              />
-              <Input
                 isRequired
                 label="规则数量"
                 max="99999"


### PR DESCRIPTION
Removed a redundant duplicate input field for Maximum Connections in the User creation/edit form.