### PR TITLE
Fix announcement update payload

### DIFF
--- a/vite-frontend/src/api/index.ts
+++ b/vite-frontend/src/api/index.ts
@@ -418,8 +418,11 @@ export interface AnnouncementData {
 
 export const getAnnouncement = () =>
   Network.get<AnnouncementData>("/announcement/get");
-export const updateAnnouncement = (data: AnnouncementData) =>
-  Network.post("/announcement/update", data);
+export const updateAnnouncement = ({
+  content,
+  enabled,
+}: Pick<AnnouncementData, "content" | "enabled">) =>
+  Network.post("/announcement/update", { content, enabled });
 
 export const getNodeMetrics = (
   nodeId: number,


### PR DESCRIPTION
## Summary
- Send only editable announcement fields when saving site settings.
- Prevent read-only `update_time` from being posted to the strict backend update endpoint.

## Test Plan
- [x] `pnpm run build`