### PR TITLE
Show current best exit state

### DIFF
--- a/docs/superpowers/plans/2026-05-01-best-exit-current-display.md
+++ b/docs/superpowers/plans/2026-05-01-best-exit-current-display.md
@@ -1,0 +1,892 @@
+# Best Exit Current Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the currently applied `best` exit selection in the tunnel list information, including per-entry/per-final-hop details for multi-owner tunnels.
+
+**Architecture:** Add a backend-only display layer that snapshots `bestExitManager` state and attaches `bestExitState` to existing `tunnelList`/`tunnelGet` responses. Render that state in the existing tunnel table/grid topology area using compact text and a native `title` detail tooltip. No routing, scoring, persistence, polling, or runtime update behavior changes.
+
+**Tech Stack:** Go `net/http` handlers + existing repository methods, React/TypeScript in `vite-frontend/src/pages/tunnel.tsx`, Tailwind/shadcn bridge components already in the file.
+
+---
+
+## File Structure
+
+- Create `go-backend/internal/http/handler/tunnel_best_exit_display.go`: response DTOs, manager snapshot method, tunnel-response parsing helpers, and `Handler.attachBestExitStates`.
+- Create `go-backend/internal/http/handler/tunnel_best_exit_display_test.go`: backend display-state unit tests.
+- Modify `go-backend/internal/http/handler/handler.go`: call `h.attachBestExitStatesOrLog(items)` in `tunnelList`.
+- Modify `go-backend/internal/http/handler/mutations.go`: call `h.attachBestExitStatesOrLog(items)` before returning a single tunnel in `tunnelGet`.
+- Modify `vite-frontend/src/pages/tunnel.tsx`: add `bestExitState` types, map API state, helper render functions, and table/grid display.
+
+---
+
+### Task 1: Backend Snapshot And Display-State Tests
+
+**Files:**
+- Create: `go-backend/internal/http/handler/tunnel_best_exit_display_test.go`
+
+- [ ] **Step 1: Write failing backend display tests**
+
+Create `go-backend/internal/http/handler/tunnel_best_exit_display_test.go`:
+
+```go
+package handler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBestExitDecisionSnapshotIsDefensiveCopy(t *testing.T) {
+	m := newBestExitManager()
+	key := bestExitOwnerKey{TunnelID: 77, OwnerNodeID: 10}
+	now := time.Unix(100, 0)
+	score := scoreBestExitCandidate(10, chainNodeRecord{NodeID: 30, NodeName: "exit-a"}, 10, 0, 20, 0)
+
+	m.observeScores(key, []bestExitCandidateScore{score}, now)
+	snapshot, ok := m.snapshot(key)
+	if !ok {
+		t.Fatalf("expected snapshot")
+	}
+	if snapshot.AppliedExitNodeID != 30 || snapshot.UpdatedAt != now.UnixMilli() {
+		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	}
+	if len(snapshot.Scores) != 1 {
+		t.Fatalf("expected one score in snapshot, got %+v", snapshot.Scores)
+	}
+	snapshot.Scores[0].ExitNodeID = 99
+
+	again, ok := m.snapshot(key)
+	if !ok {
+		t.Fatalf("expected second snapshot")
+	}
+	if again.Scores[0].ExitNodeID != 30 {
+		t.Fatalf("snapshot score mutation leaked into manager state: %+v", again.Scores)
+	}
+}
+
+func TestBuildBestExitDisplayStateForDirectMultiEntryOwners(t *testing.T) {
+	m := newBestExitManager()
+	now := time.Unix(100, 0)
+	m.setApplied(bestExitOwnerKey{TunnelID: 77, OwnerNodeID: 10}, 30, now)
+	m.setApplied(bestExitOwnerKey{TunnelID: 77, OwnerNodeID: 11}, 31, now.Add(time.Second))
+
+	tunnel := map[string]interface{}{
+		"id": int64(77),
+		"inNodeId": []map[string]interface{}{
+			{"nodeId": int64(10)},
+			{"nodeId": int64(11)},
+		},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": tunnelStrategyBest},
+			{"nodeId": int64(31), "strategy": tunnelStrategyBest},
+		},
+		"chainNodes": [][]map[string]interface{}{},
+	}
+	names := map[int64]string{10: "入口 A", 11: "入口 B", 30: "香港节点", 31: "日本节点"}
+
+	state, ok := buildBestExitDisplayState(tunnel, m, testBestExitNameLookup(names))
+	if !ok {
+		t.Fatalf("expected best exit state")
+	}
+	if !state.Enabled || state.Summary != "多个出口" || state.Status != "applied" {
+		t.Fatalf("unexpected state summary: %+v", state)
+	}
+	if state.UpdatedAt != now.Add(time.Second).UnixMilli() {
+		t.Fatalf("expected latest updatedAt, got %d", state.UpdatedAt)
+	}
+	if len(state.Items) != 2 {
+		t.Fatalf("expected two owner items, got %+v", state.Items)
+	}
+	if state.Items[0].OwnerRole != "entry" || state.Items[0].OwnerNodeName != "入口 A" || state.Items[0].ExitNodeName != "香港节点" {
+		t.Fatalf("unexpected first item: %+v", state.Items[0])
+	}
+	if state.Items[1].OwnerRole != "entry" || state.Items[1].OwnerNodeName != "入口 B" || state.Items[1].ExitNodeName != "日本节点" {
+		t.Fatalf("unexpected second item: %+v", state.Items[1])
+	}
+}
+
+func TestBuildBestExitDisplayStateForFinalChainHopOwners(t *testing.T) {
+	m := newBestExitManager()
+	now := time.Unix(200, 0)
+	m.setApplied(bestExitOwnerKey{TunnelID: 88, OwnerNodeID: 20}, 30, now)
+	m.setApplied(bestExitOwnerKey{TunnelID: 88, OwnerNodeID: 21}, 30, now.Add(time.Second))
+
+	tunnel := map[string]interface{}{
+		"id": int64(88),
+		"inNodeId": []map[string]interface{}{
+			{"nodeId": int64(10)},
+		},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": tunnelStrategyBest},
+			{"nodeId": int64(31), "strategy": tunnelStrategyBest},
+		},
+		"chainNodes": [][]map[string]interface{}{
+			{{"nodeId": int64(15), "inx": int64(0)}},
+			{{"nodeId": int64(20), "inx": int64(1)}, {"nodeId": int64(21), "inx": int64(1)}},
+		},
+	}
+	names := map[int64]string{20: "中转 M1", 21: "中转 M2", 30: "香港节点", 31: "日本节点"}
+
+	state, ok := buildBestExitDisplayState(tunnel, m, testBestExitNameLookup(names))
+	if !ok {
+		t.Fatalf("expected best exit state")
+	}
+	if state.Summary != "香港节点" || state.Status != "applied" {
+		t.Fatalf("expected single-exit summary, got %+v", state)
+	}
+	if len(state.Items) != 2 {
+		t.Fatalf("expected two final-hop owner items, got %+v", state.Items)
+	}
+	if state.Items[0].OwnerRole != "chain" || state.Items[0].OwnerNodeName != "中转 M1" || state.Items[0].ExitNodeName != "香港节点" {
+		t.Fatalf("unexpected first chain owner item: %+v", state.Items[0])
+	}
+	if state.Items[1].OwnerRole != "chain" || state.Items[1].OwnerNodeName != "中转 M2" || state.Items[1].ExitNodeName != "香港节点" {
+		t.Fatalf("unexpected second chain owner item: %+v", state.Items[1])
+	}
+}
+
+func TestBuildBestExitDisplayStateWaitingWhenNoAppliedDecisionExists(t *testing.T) {
+	tunnel := map[string]interface{}{
+		"id": int64(77),
+		"inNodeId": []map[string]interface{}{
+			{"nodeId": int64(10)},
+		},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": tunnelStrategyBest},
+			{"nodeId": int64(31), "strategy": tunnelStrategyBest},
+		},
+		"chainNodes": [][]map[string]interface{}{},
+	}
+	names := map[int64]string{10: "入口 A", 30: "香港节点", 31: "日本节点"}
+
+	state, ok := buildBestExitDisplayState(tunnel, newBestExitManager(), testBestExitNameLookup(names))
+	if !ok {
+		t.Fatalf("expected waiting best exit state")
+	}
+	if state.Summary != "等待探测" || state.Status != "waiting" {
+		t.Fatalf("expected waiting state, got %+v", state)
+	}
+	if len(state.Items) != 1 || state.Items[0].ExitNodeID != 0 || state.Items[0].ExitNodeName != "等待探测" {
+		t.Fatalf("unexpected waiting item: %+v", state.Items)
+	}
+}
+
+func TestBuildBestExitDisplayStateSkipsNonBestAndSingleExitTunnels(t *testing.T) {
+	nonBest := map[string]interface{}{
+		"id":       int64(77),
+		"inNodeId": []map[string]interface{}{{"nodeId": int64(10)}},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": "round"},
+			{"nodeId": int64(31), "strategy": "round"},
+		},
+	}
+	if state, ok := buildBestExitDisplayState(nonBest, newBestExitManager(), testBestExitNameLookup(nil)); ok || state != nil {
+		t.Fatalf("expected non-best tunnel to skip state, got %+v", state)
+	}
+
+	singleExit := map[string]interface{}{
+		"id":       int64(78),
+		"inNodeId": []map[string]interface{}{{"nodeId": int64(10)}},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": tunnelStrategyBest},
+		},
+	}
+	if state, ok := buildBestExitDisplayState(singleExit, newBestExitManager(), testBestExitNameLookup(nil)); ok || state != nil {
+		t.Fatalf("expected single-exit tunnel to skip state, got %+v", state)
+	}
+}
+
+func testBestExitNameLookup(names map[int64]string) bestExitNodeNameLookup {
+	return func(nodeID int64) (string, bool) {
+		name := names[nodeID]
+		return name, name != ""
+	}
+}
+```
+
+- [ ] **Step 2: Run backend display tests to verify failure**
+
+Run from `go-backend`:
+
+```bash
+go test ./internal/http/handler -run 'TestBestExitDecisionSnapshot|TestBuildBestExitDisplayState' -count=1
+```
+
+Expected: FAIL with undefined `snapshot`, `buildBestExitDisplayState`, and `bestExitNodeNameLookup`.
+
+---
+
+### Task 2: Backend Display State Implementation
+
+**Files:**
+- Create: `go-backend/internal/http/handler/tunnel_best_exit_display.go`
+- Modify: `go-backend/internal/http/handler/tunnel_best_exit.go`
+- Test: `go-backend/internal/http/handler/tunnel_best_exit_display_test.go`
+
+- [ ] **Step 1: Implement display state and snapshot helpers**
+
+Create `go-backend/internal/http/handler/tunnel_best_exit_display.go`:
+
+```go
+package handler
+
+import (
+	"log"
+	"strings"
+)
+
+const (
+	bestExitDisplayStatusApplied = "applied"
+	bestExitDisplayStatusWaiting = "waiting"
+	bestExitDisplaySummaryMulti  = "多个出口"
+	bestExitDisplaySummaryWait   = "等待探测"
+	bestExitUnknownExitName      = "未知出口"
+	bestExitUnknownEntryName     = "未知入口"
+	bestExitUnknownChainName     = "未知中转"
+)
+
+type bestExitDecisionSnapshot struct {
+	AppliedExitNodeID int64
+	UpdatedAt         int64
+	Reason            string
+	Scores            []bestExitCandidateScore
+}
+
+type bestExitDisplayState struct {
+	Enabled   bool                  `json:"enabled"`
+	Summary   string                `json:"summary"`
+	Status    string                `json:"status"`
+	UpdatedAt int64                 `json:"updatedAt,omitempty"`
+	Reason    string                `json:"reason,omitempty"`
+	Items     []bestExitDisplayItem `json:"items"`
+}
+
+type bestExitDisplayItem struct {
+	OwnerNodeID   int64  `json:"ownerNodeId"`
+	OwnerNodeName string `json:"ownerNodeName"`
+	OwnerRole     string `json:"ownerRole"`
+	ExitNodeID    int64  `json:"exitNodeId,omitempty"`
+	ExitNodeName  string `json:"exitNodeName"`
+	UpdatedAt     int64  `json:"updatedAt,omitempty"`
+	Reason        string `json:"reason,omitempty"`
+}
+
+type bestExitNodeNameLookup func(nodeID int64) (string, bool)
+
+func (m *bestExitManager) snapshot(key bestExitOwnerKey) (bestExitDecisionSnapshot, bool) {
+	if m == nil {
+		return bestExitDecisionSnapshot{}, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d := m.decisions[key]
+	if d == nil {
+		return bestExitDecisionSnapshot{}, false
+	}
+	updatedAt := int64(0)
+	if !d.LastSwitchAt.IsZero() {
+		updatedAt = d.LastSwitchAt.UnixMilli()
+	}
+	return bestExitDecisionSnapshot{
+		AppliedExitNodeID: d.AppliedExitNodeID,
+		UpdatedAt:         updatedAt,
+		Reason:            d.LastReason,
+		Scores:            cloneBestExitScores(d.Scores),
+	}, true
+}
+
+func (h *Handler) attachBestExitStates(items []map[string]interface{}) {
+	if h == nil || len(items) == 0 {
+		return
+	}
+	lookup := h.bestExitNodeNameLookup()
+	for _, item := range items {
+		state, ok := buildBestExitDisplayState(item, h.bestExit, lookup)
+		if !ok {
+			delete(item, "bestExitState")
+			continue
+		}
+		item["bestExitState"] = state
+	}
+}
+
+func (h *Handler) bestExitNodeNameLookup() bestExitNodeNameLookup {
+	cache := map[int64]string{}
+	return func(nodeID int64) (string, bool) {
+		if nodeID <= 0 || h == nil {
+			return "", false
+		}
+		if name, ok := cache[nodeID]; ok {
+			return name, name != ""
+		}
+		node, err := h.getNodeRecord(nodeID)
+		if err != nil || node == nil {
+			cache[nodeID] = ""
+			return "", false
+		}
+		name := strings.TrimSpace(node.Name)
+		cache[nodeID] = name
+		return name, name != ""
+	}
+}
+
+func buildBestExitDisplayState(tunnel map[string]interface{}, manager *bestExitManager, lookup bestExitNodeNameLookup) (*bestExitDisplayState, bool) {
+	if tunnel == nil {
+		return nil, false
+	}
+	tunnelID := asInt64(tunnel["id"], 0)
+	outNodes := bestExitDisplayMapSlice(tunnel["outNodeId"])
+	if tunnelID <= 0 || len(outNodes) <= 1 {
+		return nil, false
+	}
+	if !isBestTunnelStrategy(asString(outNodes[0]["strategy"])) {
+		return nil, false
+	}
+
+	owners, ownerRole := bestExitDisplayOwners(tunnel)
+	state := &bestExitDisplayState{
+		Enabled: true,
+		Summary: bestExitDisplaySummaryWait,
+		Status:  bestExitDisplayStatusWaiting,
+		Items:   make([]bestExitDisplayItem, 0, len(owners)),
+	}
+
+	exitsByID := map[int64]map[string]interface{}{}
+	for _, exit := range outNodes {
+		if id := asInt64(exit["nodeId"], 0); id > 0 {
+			exitsByID[id] = exit
+		}
+	}
+	appliedExitIDs := map[int64]string{}
+	appliedCount := 0
+	latestUpdatedAt := int64(0)
+	latestReason := ""
+	for _, owner := range owners {
+		ownerNodeID := asInt64(owner["nodeId"], 0)
+		if ownerNodeID <= 0 {
+			continue
+		}
+		item := bestExitDisplayItem{
+			OwnerNodeID:   ownerNodeID,
+			OwnerNodeName: bestExitDisplayNodeName(owner, ownerNodeID, lookup, bestExitUnknownOwnerName(ownerRole)),
+			OwnerRole:     ownerRole,
+			ExitNodeName:  bestExitDisplaySummaryWait,
+			Reason:        bestExitDisplayStatusWaiting,
+		}
+		if snapshot, ok := manager.snapshot(bestExitOwnerKey{TunnelID: tunnelID, OwnerNodeID: ownerNodeID}); ok && snapshot.AppliedExitNodeID > 0 {
+			item.ExitNodeID = snapshot.AppliedExitNodeID
+			item.ExitNodeName = bestExitDisplayNodeName(exitsByID[snapshot.AppliedExitNodeID], snapshot.AppliedExitNodeID, lookup, bestExitUnknownExitName)
+			item.UpdatedAt = snapshot.UpdatedAt
+			item.Reason = snapshot.Reason
+			appliedExitIDs[item.ExitNodeID] = item.ExitNodeName
+			appliedCount++
+			if snapshot.UpdatedAt > latestUpdatedAt {
+				latestUpdatedAt = snapshot.UpdatedAt
+				latestReason = snapshot.Reason
+			}
+		}
+		state.Items = append(state.Items, item)
+	}
+
+	if appliedCount == 0 {
+		return state, true
+	}
+	state.Status = bestExitDisplayStatusApplied
+	state.UpdatedAt = latestUpdatedAt
+	state.Reason = latestReason
+	if len(appliedExitIDs) == 1 {
+		for _, name := range appliedExitIDs {
+			state.Summary = name
+		}
+	} else {
+		state.Summary = bestExitDisplaySummaryMulti
+	}
+	return state, true
+}
+
+func bestExitDisplayOwners(tunnel map[string]interface{}) ([]map[string]interface{}, string) {
+	chainGroups := bestExitDisplayChainGroups(tunnel["chainNodes"])
+	if len(chainGroups) > 0 {
+		return chainGroups[len(chainGroups)-1], "chain"
+	}
+	return bestExitDisplayMapSlice(tunnel["inNodeId"]), "entry"
+}
+
+func bestExitDisplayMapSlice(v interface{}) []map[string]interface{} {
+	switch arr := v.(type) {
+	case []map[string]interface{}:
+		return arr
+	case []interface{}:
+		out := make([]map[string]interface{}, 0, len(arr))
+		for _, item := range arr {
+			if m, ok := item.(map[string]interface{}); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func bestExitDisplayChainGroups(v interface{}) [][]map[string]interface{} {
+	switch groups := v.(type) {
+	case [][]map[string]interface{}:
+		return groups
+	case []interface{}:
+		out := make([][]map[string]interface{}, 0, len(groups))
+		for _, group := range groups {
+			items := bestExitDisplayMapSlice(group)
+			if len(items) > 0 {
+				out = append(out, items)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func bestExitDisplayNodeName(source map[string]interface{}, nodeID int64, lookup bestExitNodeNameLookup, fallback string) string {
+	if source != nil {
+		for _, key := range []string{"nodeName", "name"} {
+			if name := strings.TrimSpace(asString(source[key])); name != "" {
+				return name
+			}
+		}
+	}
+	if lookup != nil {
+		if name, ok := lookup(nodeID); ok && strings.TrimSpace(name) != "" {
+			return strings.TrimSpace(name)
+		}
+	}
+	return fallback
+}
+
+func bestExitUnknownOwnerName(role string) string {
+	if role == "chain" {
+		return bestExitUnknownChainName
+	}
+	return bestExitUnknownEntryName
+}
+
+func (h *Handler) attachBestExitStatesOrLog(items []map[string]interface{}) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			log.Printf("best_exit: attach display state failed: %v", recovered)
+		}
+	}()
+	h.attachBestExitStates(items)
+}
+```
+
+- [ ] **Step 2: Replace direct attach calls with panic-safe wrapper**
+
+Keep `attachBestExitStates` for tests, and use `attachBestExitStatesOrLog` from handlers in Task 3. This step only creates the function above; no handler wiring yet.
+
+- [ ] **Step 3: Run backend display tests**
+
+Run from `go-backend`:
+
+```bash
+go test ./internal/http/handler -run 'TestBestExitDecisionSnapshot|TestBuildBestExitDisplayState' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run gofmt**
+
+```bash
+gofmt -w internal/http/handler/tunnel_best_exit_display.go internal/http/handler/tunnel_best_exit_display_test.go
+```
+
+- [ ] **Step 5: Commit backend display implementation**
+
+```bash
+git add go-backend/internal/http/handler/tunnel_best_exit_display.go go-backend/internal/http/handler/tunnel_best_exit_display_test.go
+git commit -m "feat: build best exit display state"
+```
+
+---
+
+### Task 3: Attach Best-Exit State To Tunnel List And Get Responses
+
+**Files:**
+- Modify: `go-backend/internal/http/handler/handler.go`
+- Modify: `go-backend/internal/http/handler/mutations.go`
+- Test: `go-backend/internal/http/handler/tunnel_best_exit_display_test.go`
+
+- [ ] **Step 1: Write failing handler attach tests**
+
+Append to `go-backend/internal/http/handler/tunnel_best_exit_display_test.go`:
+
+```go
+func TestAttachBestExitStatesAddsStateToBestTunnelOnly(t *testing.T) {
+	h := &Handler{bestExit: newBestExitManager()}
+	now := time.Unix(300, 0)
+	h.bestExit.setApplied(bestExitOwnerKey{TunnelID: 77, OwnerNodeID: 10}, 30, now)
+
+	items := []map[string]interface{}{
+		{
+			"id":       int64(77),
+			"inNodeId": []map[string]interface{}{{"nodeId": int64(10)}},
+			"outNodeId": []map[string]interface{}{
+				{"nodeId": int64(30), "strategy": tunnelStrategyBest},
+				{"nodeId": int64(31), "strategy": tunnelStrategyBest},
+			},
+		},
+		{
+			"id":       int64(78),
+			"inNodeId": []map[string]interface{}{{"nodeId": int64(12)}},
+			"outNodeId": []map[string]interface{}{
+				{"nodeId": int64(40), "strategy": "round"},
+				{"nodeId": int64(41), "strategy": "round"},
+			},
+		},
+	}
+
+	h.attachBestExitStates(items)
+	state, ok := items[0]["bestExitState"].(*bestExitDisplayState)
+	if !ok {
+		t.Fatalf("expected bestExitState on best tunnel, got %#v", items[0]["bestExitState"])
+	}
+	if state.Summary != bestExitUnknownExitName || state.Items[0].ExitNodeID != 30 {
+		t.Fatalf("unexpected state with fallback names: %+v", state)
+	}
+	if _, exists := items[1]["bestExitState"]; exists {
+		t.Fatalf("non-best tunnel should not have bestExitState: %+v", items[1])
+	}
+}
+```
+
+- [ ] **Step 2: Run attach test to verify failure**
+
+Run from `go-backend`:
+
+```bash
+go test ./internal/http/handler -run TestAttachBestExitStatesAddsStateToBestTunnelOnly -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Wire tunnel list response**
+
+In `go-backend/internal/http/handler/handler.go`, change `tunnelList` from:
+
+```go
+	items, err := h.repo.ListTunnels()
+	if err != nil {
+		response.WriteJSON(w, response.Err(-2, err.Error()))
+		return
+	}
+	response.WriteJSON(w, response.OK(items))
+```
+
+to:
+
+```go
+	items, err := h.repo.ListTunnels()
+	if err != nil {
+		response.WriteJSON(w, response.Err(-2, err.Error()))
+		return
+	}
+	h.attachBestExitStatesOrLog(items)
+	response.WriteJSON(w, response.OK(items))
+```
+
+- [ ] **Step 4: Wire single tunnel response**
+
+In `go-backend/internal/http/handler/mutations.go`, change `tunnelGet` from:
+
+```go
+	items, err := h.repo.ListTunnels()
+	if err != nil {
+		response.WriteJSON(w, response.Err(-2, err.Error()))
+		return
+	}
+	for _, it := range items {
+		if asInt64(it["id"], 0) == id {
+			response.WriteJSON(w, response.OK(it))
+			return
+		}
+	}
+```
+
+to:
+
+```go
+	items, err := h.repo.ListTunnels()
+	if err != nil {
+		response.WriteJSON(w, response.Err(-2, err.Error()))
+		return
+	}
+	h.attachBestExitStatesOrLog(items)
+	for _, it := range items {
+		if asInt64(it["id"], 0) == id {
+			response.WriteJSON(w, response.OK(it))
+			return
+		}
+	}
+```
+
+- [ ] **Step 5: Run focused backend tests**
+
+Run from `go-backend`:
+
+```bash
+go test ./internal/http/handler -run 'TestBestExitDecisionSnapshot|TestBuildBestExitDisplayState|TestAttachBestExitStatesAddsStateToBestTunnelOnly' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run gofmt**
+
+```bash
+gofmt -w internal/http/handler/handler.go internal/http/handler/mutations.go internal/http/handler/tunnel_best_exit_display.go internal/http/handler/tunnel_best_exit_display_test.go
+```
+
+- [ ] **Step 7: Commit response wiring**
+
+```bash
+git add go-backend/internal/http/handler/handler.go go-backend/internal/http/handler/mutations.go go-backend/internal/http/handler/tunnel_best_exit_display.go go-backend/internal/http/handler/tunnel_best_exit_display_test.go
+git commit -m "feat: expose best exit display state"
+```
+
+---
+
+### Task 4: Frontend Tunnel List Display
+
+**Files:**
+- Modify: `vite-frontend/src/pages/tunnel.tsx`
+
+- [ ] **Step 1: Add TypeScript types**
+
+In `vite-frontend/src/pages/tunnel.tsx`, add these interfaces after `interface ChainTunnel`:
+
+```ts
+interface BestExitStateItem {
+  ownerNodeId: number;
+  ownerNodeName: string;
+  ownerRole: "entry" | "chain";
+  exitNodeId?: number;
+  exitNodeName: string;
+  updatedAt?: number;
+  reason?: string;
+}
+
+interface BestExitState {
+  enabled: boolean;
+  summary: string;
+  status: "applied" | "waiting";
+  updatedAt?: number;
+  reason?: string;
+  items: BestExitStateItem[];
+}
+```
+
+Then add the optional field to `interface Tunnel`:
+
+```ts
+  bestExitState?: BestExitState | null;
+```
+
+- [ ] **Step 2: Preserve API state during mapping**
+
+In `mapTunnelApiItems`, add `bestExitState` to the returned object:
+
+```ts
+    bestExitState:
+      tunnel.bestExitState && typeof tunnel.bestExitState === "object"
+        ? {
+            ...tunnel.bestExitState,
+            items: Array.isArray(tunnel.bestExitState.items)
+              ? tunnel.bestExitState.items
+              : [],
+          }
+        : null,
+```
+
+The mapped object should include this field before `createdTime` or immediately after it.
+
+- [ ] **Step 3: Add render helpers**
+
+Add these helper functions after `mapTunnelApiItems` and before `export default function TunnelPage()`:
+
+```tsx
+const bestExitOwnerRoleText = (role: BestExitStateItem["ownerRole"]) => {
+  return role === "chain" ? "中转" : "入口";
+};
+
+const bestExitDetailTitle = (state?: BestExitState | null) => {
+  if (!state?.enabled || !state.items?.length) {
+    return "";
+  }
+  return state.items
+    .map((item) => {
+      const ownerName = item.ownerNodeName || `${bestExitOwnerRoleText(item.ownerRole)} ${item.ownerNodeId}`;
+      const exitName = item.exitNodeName || "等待探测";
+      return `${ownerName} -> ${exitName}`;
+    })
+    .join("\n");
+};
+
+const renderBestExitState = (state?: BestExitState | null) => {
+  if (!state?.enabled) {
+    return null;
+  }
+  const title = bestExitDetailTitle(state);
+  const isWaiting = state.status === "waiting";
+
+  return (
+    <div
+      className={`mt-1 text-[11px] leading-4 ${
+        isWaiting
+          ? "text-default-500"
+          : "text-emerald-700 dark:text-emerald-300"
+      }`}
+      title={title || undefined}
+    >
+      最优出口：{state.summary || "等待探测"}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Render in table topology cell**
+
+In the table topology `<TableCell>` around line 1674, change the cell content from:
+
+```tsx
+                        <div className="flex items-center gap-1.5 text-xs">
+                          <span className="font-semibold text-primary-700 dark:text-primary-400">
+                            {tunnel.inNodeId?.length || 0}入口
+                          </span>
+                          <span className="text-default-400">→</span>
+                          <span className="font-semibold text-secondary-700 dark:text-secondary-400">
+                            {tunnel.type === 2
+                              ? tunnel.chainNodes?.length || 0
+                              : 0}
+                            跳
+                          </span>
+                          <span className="text-default-400">→</span>
+                          <span className="font-semibold text-success-700 dark:text-success-400">
+                            {tunnel.type === 2
+                              ? tunnel.outNodeId?.length || 0
+                              : tunnel.inNodeId?.length || 0}
+                            出口
+                          </span>
+                        </div>
+```
+
+to:
+
+```tsx
+                        <div>
+                          <div className="flex items-center gap-1.5 text-xs">
+                            <span className="font-semibold text-primary-700 dark:text-primary-400">
+                              {tunnel.inNodeId?.length || 0}入口
+                            </span>
+                            <span className="text-default-400">→</span>
+                            <span className="font-semibold text-secondary-700 dark:text-secondary-400">
+                              {tunnel.type === 2
+                                ? tunnel.chainNodes?.length || 0
+                                : 0}
+                              跳
+                            </span>
+                            <span className="text-default-400">→</span>
+                            <span className="font-semibold text-success-700 dark:text-success-400">
+                              {tunnel.type === 2
+                                ? tunnel.outNodeId?.length || 0
+                                : tunnel.inNodeId?.length || 0}
+                              出口
+                            </span>
+                          </div>
+                          {renderBestExitState(tunnel.bestExitState)}
+                        </div>
+```
+
+- [ ] **Step 5: Render in grid card topology section**
+
+In the grid card topology section, after the closing `</div>` for the topology row at the end of the block containing `出口` and before the enclosing border section closes, add:
+
+```tsx
+                                <div className="text-center">
+                                  {renderBestExitState(tunnel.bestExitState)}
+                                </div>
+```
+
+The result should put the best-exit summary under the entry -> hop -> exit row inside the topology section.
+
+- [ ] **Step 6: Run frontend build**
+
+Run from `vite-frontend`:
+
+```bash
+pnpm run build
+```
+
+Expected: PASS with `tsc && vite build` completing successfully.
+
+- [ ] **Step 7: Commit frontend display**
+
+```bash
+git add vite-frontend/src/pages/tunnel.tsx
+git commit -m "feat: show current best exit in tunnel list"
+```
+
+---
+
+### Task 5: Full Verification And Review
+
+**Files:**
+- Verify only.
+
+- [ ] **Step 1: Run backend tests**
+
+Run from `go-backend`:
+
+```bash
+go test ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend build**
+
+Run from `vite-frontend`:
+
+```bash
+pnpm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect final diff**
+
+Run from repository root:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff -- go-backend/internal/http/handler/tunnel_best_exit_display.go go-backend/internal/http/handler/tunnel_best_exit_display_test.go go-backend/internal/http/handler/handler.go go-backend/internal/http/handler/mutations.go vite-frontend/src/pages/tunnel.tsx
+```
+
+Expected: Diff only adds best-exit display state, response attachment, frontend list display, and tests. It must not change best-exit scoring, switching, runtime chain update, or agent code.
+
+- [ ] **Step 4: Request final code review**
+
+Ask a reviewer to check:
+
+```text
+Review the best-exit current display implementation. Confirm it only exposes current in-memory best-exit state in tunnel list/get responses and renders it in the tunnel list. Verify it does not change routing, scoring, switching, persistence, or polling behavior.
+```
+
+Expected: No blocking findings.
+
+---
+
+## Self-Review
+
+- Spec coverage: Backend response state is Task 2 and Task 3; direct vs final-hop owner semantics are covered by Task 1 tests; frontend list/grid display is Task 4; no polling and no routing changes are preserved by Task 5 review instructions.
+- Placeholder scan: The plan contains concrete files, function names, code blocks, commands, and expected outcomes.
+- Type consistency: `BestExitState`, `BestExitStateItem`, `bestExitDisplayState`, `bestExitDisplayItem`, `bestExitDecisionSnapshot`, and `bestExitNodeNameLookup` are defined before use and names match across tasks.

--- a/docs/superpowers/specs/2026-05-01-best-exit-current-display-design.md
+++ b/docs/superpowers/specs/2026-05-01-best-exit-current-display-design.md
@@ -1,0 +1,156 @@
+# Best Exit Current Selection Display Design
+
+## Goal
+
+When a tunnel uses the `best` multi-exit strategy, show the currently applied best exit in the tunnel list information. Users should be able to see which exit is currently selected without opening logs or diagnosing the tunnel manually.
+
+The display is informational only. It must not change routing, scoring, switching behavior, or the saved tunnel configuration.
+
+## Current Context
+
+- `3.0.0-beta6` adds `best` as a multi-exit strategy.
+- Runtime selection is stored in the backend `bestExitManager` in memory, keyed by `TunnelID + OwnerNodeID`.
+- Direct multi-entry tunnels make one independent best-exit decision per entry node.
+- Tunnels with intermediate chain hops make one independent best-exit decision per final-hop chain node before the exits.
+- `tunnelList` and `tunnelGet` currently return `repo.ListTunnels()` output directly, so frontend tunnel data only includes configured exits from the database, not the currently applied runtime choice.
+- The frontend tunnel page maps API items in `vite-frontend/src/pages/tunnel.tsx` and renders list information from that data.
+
+## User Decisions
+
+- Show the current best-exit choice in the tunnel list information.
+- Use a summary plus detail model for multiple owners.
+- Follow the existing tunnel list refresh cadence; do not add polling or a realtime stream in this phase.
+- Work text-only; no visual companion is needed.
+
+## Approach
+
+Extend the existing tunnel list/detail response with a lightweight runtime state object for `best` tunnels, then render that state beside the tunnel's exit/strategy information in the existing frontend list UI.
+
+This keeps the display close to the data users already inspect and avoids a separate API or extra frontend request.
+
+## Backend Design
+
+### Response Shape
+
+Add a `bestExitState` object to each tunnel item returned by `tunnelList` and `tunnelGet` when the tunnel has a multi-exit group whose strategy is `best`.
+
+Response shape:
+
+```json
+{
+  "enabled": true,
+  "summary": "香港节点",
+  "status": "applied",
+  "updatedAt": 1777584000000,
+  "reason": "current exit remains best",
+  "items": [
+    {
+      "ownerNodeId": 10,
+      "ownerNodeName": "入口 A",
+      "ownerRole": "entry",
+      "exitNodeId": 30,
+      "exitNodeName": "香港节点",
+      "updatedAt": 1777584000000,
+      "reason": "current exit remains best"
+    }
+  ]
+}
+```
+
+If the tunnel is not using `best`, omit `bestExitState` or set it to `null`.
+
+### Owner Semantics
+
+The display must match the routing model:
+
+- If there are no middle chain hops, each entry node is an owner.
+- If there are middle chain hops, each node in the final middle-hop group is an owner.
+
+Each owner can have a different current best exit. The UI must not imply that a multi-owner tunnel has one global best exit when the owners differ.
+
+### Summary Rules
+
+- If all owners currently apply the same exit, `summary` is that exit node name.
+- If owners apply different exits, `summary` is `多个出口`.
+- If no applied decision exists yet, `summary` is `等待探测`.
+- If the tunnel has only one exit, `bestExitState` is not needed because there is no dynamic choice.
+
+### State Source
+
+Use the in-memory `bestExitManager` as the source of currently applied decisions.
+
+Add a read-only snapshot method that returns defensive copies of decision state without exposing mutable internal slices. The handler should convert node IDs to display names from the existing tunnel response data first, then fall back to `h.getNodeRecord` only when the current response does not contain the node.
+
+The feature should not persist current choices to the database in this phase. A panel restart may reset the displayed runtime state to `等待探测` until the prober initializes it again from the current saved first exit.
+
+## Frontend Design
+
+Extend the tunnel item type with optional `bestExitState`.
+
+In the tunnel list, only render the current best-exit display when:
+
+- `bestExitState.enabled === true`, or
+- the tunnel has an exit group with `strategy === "best"` and the backend returns a waiting state.
+
+Display format:
+
+- Single applied exit: `最优出口：香港节点`
+- Multiple applied exits: `最优出口：多个出口`
+- Waiting: `最优出口：等待探测`
+
+For multiple owners, render the summary as compact secondary text in the topology/list information cell and set its native `title` attribute to newline-separated detail rows. This avoids adding a new UI dependency or a custom popover. Detail rows should use:
+
+```text
+入口 A -> 香港节点
+入口 B -> 日本节点
+```
+
+For tunnels with middle chain hops, label owners as chain nodes when useful:
+
+```text
+中转 M1 -> 香港节点
+中转 M2 -> 日本节点
+```
+
+Do not add a new periodic refresh. The display updates when the existing tunnel list is refreshed.
+
+## Error Handling
+
+- If the manager has no decision for an owner, show that owner as `等待探测`.
+- If an exit node ID no longer exists in the current tunnel response, show `未知出口` for that item and keep the list usable.
+- If an owner node ID no longer exists, show `未知入口` or `未知中转` based on the owner role.
+- If the backend cannot compute state for one tunnel, omit `bestExitState` for that tunnel and log the error; do not fail the whole tunnel list response.
+
+## Testing
+
+Backend tests:
+
+- `bestExitManager` snapshot returns applied exit IDs without exposing mutable manager state.
+- Direct multi-entry `best` tunnel produces one display item per entry owner.
+- Middle-hop tunnel produces one display item per final-hop owner.
+- Summary is the single exit name when all owners choose the same exit.
+- Summary is `多个出口` when owners choose different exits.
+- Summary is `等待探测` when no applied decision exists.
+- Non-`best` tunnels do not receive `bestExitState`.
+
+Frontend verification:
+
+- Tunnel list renders `最优出口：<name>` for a single applied exit.
+- Tunnel list renders `最优出口：多个出口` plus owner details for multiple applied exits.
+- Tunnel list renders `最优出口：等待探测` for waiting state.
+- `pnpm run build` passes.
+
+Verification commands:
+
+```bash
+(cd go-backend && go test ./...)
+(cd vite-frontend && pnpm run build)
+```
+
+## Non-Goals
+
+- Do not add a new realtime stream or polling loop.
+- Do not add a detailed best-exit scoring dashboard.
+- Do not persist current best-exit choices to the database.
+- Do not change switching thresholds, probing targets, or runtime chain update behavior.
+- Do not change existing non-`best` tunnel display behavior.

--- a/go-backend/internal/http/handler/handler.go
+++ b/go-backend/internal/http/handler/handler.go
@@ -475,6 +475,7 @@ func (h *Handler) tunnelList(w http.ResponseWriter, r *http.Request) {
 		response.WriteJSON(w, response.Err(-2, err.Error()))
 		return
 	}
+	h.attachBestExitStates(items)
 	response.WriteJSON(w, response.OK(items))
 }
 

--- a/go-backend/internal/http/handler/mutations.go
+++ b/go-backend/internal/http/handler/mutations.go
@@ -842,6 +842,7 @@ func (h *Handler) tunnelGet(w http.ResponseWriter, r *http.Request) {
 		response.WriteJSON(w, response.Err(-2, err.Error()))
 		return
 	}
+	h.attachBestExitStates(items)
 	for _, it := range items {
 		if asInt64(it["id"], 0) == id {
 			response.WriteJSON(w, response.OK(it))

--- a/go-backend/internal/http/handler/tunnel_best_exit_display.go
+++ b/go-backend/internal/http/handler/tunnel_best_exit_display.go
@@ -1,0 +1,248 @@
+package handler
+
+import (
+	"strings"
+)
+
+const (
+	bestExitDisplayStatusApplied = "applied"
+	bestExitDisplayStatusWaiting = "waiting"
+	bestExitDisplaySummaryMulti  = "多个出口"
+	bestExitDisplaySummaryWait   = "等待探测"
+	bestExitUnknownExitName      = "未知出口"
+	bestExitUnknownEntryName     = "未知入口"
+	bestExitUnknownChainName     = "未知中转"
+)
+
+type bestExitDecisionSnapshot struct {
+	AppliedExitNodeID int64
+	UpdatedAt         int64
+	Reason            string
+	Scores            []bestExitCandidateScore
+}
+
+type bestExitDisplayState struct {
+	Enabled   bool                  `json:"enabled"`
+	Summary   string                `json:"summary"`
+	Status    string                `json:"status"`
+	UpdatedAt int64                 `json:"updatedAt,omitempty"`
+	Reason    string                `json:"reason,omitempty"`
+	Items     []bestExitDisplayItem `json:"items"`
+}
+
+type bestExitDisplayItem struct {
+	OwnerNodeID   int64  `json:"ownerNodeId"`
+	OwnerNodeName string `json:"ownerNodeName"`
+	OwnerRole     string `json:"ownerRole"`
+	ExitNodeID    int64  `json:"exitNodeId,omitempty"`
+	ExitNodeName  string `json:"exitNodeName"`
+	UpdatedAt     int64  `json:"updatedAt,omitempty"`
+	Reason        string `json:"reason,omitempty"`
+}
+
+type bestExitNodeNameLookup func(nodeID int64) (string, bool)
+
+func (m *bestExitManager) snapshot(key bestExitOwnerKey) (bestExitDecisionSnapshot, bool) {
+	if m == nil {
+		return bestExitDecisionSnapshot{}, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d := m.decisions[key]
+	if d == nil {
+		return bestExitDecisionSnapshot{}, false
+	}
+	updatedAt := int64(0)
+	if !d.LastSwitchAt.IsZero() {
+		updatedAt = d.LastSwitchAt.UnixMilli()
+	}
+	return bestExitDecisionSnapshot{
+		AppliedExitNodeID: d.AppliedExitNodeID,
+		UpdatedAt:         updatedAt,
+		Reason:            d.LastReason,
+		Scores:            cloneBestExitScores(d.Scores),
+	}, true
+}
+
+func (h *Handler) attachBestExitStates(items []map[string]interface{}) {
+	if h == nil || len(items) == 0 {
+		return
+	}
+	lookup := h.bestExitNodeNameLookup()
+	for _, item := range items {
+		state, ok := buildBestExitDisplayState(item, h.bestExit, lookup)
+		if !ok {
+			delete(item, "bestExitState")
+			continue
+		}
+		item["bestExitState"] = state
+	}
+}
+
+func (h *Handler) bestExitNodeNameLookup() bestExitNodeNameLookup {
+	cache := map[int64]string{}
+	return func(nodeID int64) (string, bool) {
+		if nodeID <= 0 || h == nil {
+			return "", false
+		}
+		if name, ok := cache[nodeID]; ok {
+			return name, name != ""
+		}
+		node, err := h.getNodeRecord(nodeID)
+		if err != nil || node == nil {
+			cache[nodeID] = ""
+			return "", false
+		}
+		name := strings.TrimSpace(node.Name)
+		cache[nodeID] = name
+		return name, name != ""
+	}
+}
+
+func buildBestExitDisplayState(tunnel map[string]interface{}, manager *bestExitManager, lookup bestExitNodeNameLookup) (*bestExitDisplayState, bool) {
+	if tunnel == nil {
+		return nil, false
+	}
+	tunnelID := asInt64(tunnel["id"], 0)
+	outNodes := bestExitDisplayMapSlice(tunnel["outNodeId"])
+	if tunnelID <= 0 || len(outNodes) <= 1 {
+		return nil, false
+	}
+	if !isBestTunnelStrategy(asString(outNodes[0]["strategy"])) {
+		return nil, false
+	}
+
+	owners, ownerRole := bestExitDisplayOwners(tunnel)
+	state := &bestExitDisplayState{
+		Enabled: true,
+		Summary: bestExitDisplaySummaryWait,
+		Status:  bestExitDisplayStatusWaiting,
+		Items:   make([]bestExitDisplayItem, 0, len(owners)),
+	}
+
+	exitsByID := map[int64]map[string]interface{}{}
+	for _, exit := range outNodes {
+		if id := asInt64(exit["nodeId"], 0); id > 0 {
+			exitsByID[id] = exit
+		}
+	}
+	appliedExitIDs := map[int64]string{}
+	appliedCount := 0
+	latestUpdatedAt := int64(0)
+	latestReason := ""
+	for _, owner := range owners {
+		ownerNodeID := asInt64(owner["nodeId"], 0)
+		if ownerNodeID <= 0 {
+			continue
+		}
+		item := bestExitDisplayItem{
+			OwnerNodeID:   ownerNodeID,
+			OwnerNodeName: bestExitDisplayNodeName(owner, ownerNodeID, lookup, bestExitUnknownOwnerName(ownerRole)),
+			OwnerRole:     ownerRole,
+			ExitNodeName:  bestExitDisplaySummaryWait,
+			Reason:        bestExitDisplayStatusWaiting,
+		}
+		if snapshot, ok := manager.snapshot(bestExitOwnerKey{TunnelID: tunnelID, OwnerNodeID: ownerNodeID}); ok && snapshot.AppliedExitNodeID > 0 {
+			exit, ok := exitsByID[snapshot.AppliedExitNodeID]
+			if !ok {
+				state.Items = append(state.Items, item)
+				continue
+			}
+			item.ExitNodeID = snapshot.AppliedExitNodeID
+			item.ExitNodeName = bestExitDisplayNodeName(exit, snapshot.AppliedExitNodeID, lookup, bestExitUnknownExitName)
+			item.UpdatedAt = snapshot.UpdatedAt
+			item.Reason = snapshot.Reason
+			appliedExitIDs[item.ExitNodeID] = item.ExitNodeName
+			appliedCount++
+			if snapshot.UpdatedAt > latestUpdatedAt {
+				latestUpdatedAt = snapshot.UpdatedAt
+				latestReason = snapshot.Reason
+			}
+		}
+		state.Items = append(state.Items, item)
+	}
+
+	if appliedCount == 0 {
+		return state, true
+	}
+	if appliedCount < len(state.Items) {
+		return state, true
+	}
+	state.Status = bestExitDisplayStatusApplied
+	state.UpdatedAt = latestUpdatedAt
+	state.Reason = latestReason
+	if len(appliedExitIDs) == 1 {
+		for _, name := range appliedExitIDs {
+			state.Summary = name
+		}
+	} else {
+		state.Summary = bestExitDisplaySummaryMulti
+	}
+	return state, true
+}
+
+func bestExitDisplayOwners(tunnel map[string]interface{}) ([]map[string]interface{}, string) {
+	chainGroups := bestExitDisplayChainGroups(tunnel["chainNodes"])
+	if len(chainGroups) > 0 {
+		return chainGroups[len(chainGroups)-1], "chain"
+	}
+	return bestExitDisplayMapSlice(tunnel["inNodeId"]), "entry"
+}
+
+func bestExitDisplayMapSlice(v interface{}) []map[string]interface{} {
+	switch arr := v.(type) {
+	case []map[string]interface{}:
+		return arr
+	case []interface{}:
+		out := make([]map[string]interface{}, 0, len(arr))
+		for _, item := range arr {
+			if m, ok := item.(map[string]interface{}); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func bestExitDisplayChainGroups(v interface{}) [][]map[string]interface{} {
+	switch groups := v.(type) {
+	case [][]map[string]interface{}:
+		return groups
+	case []interface{}:
+		out := make([][]map[string]interface{}, 0, len(groups))
+		for _, group := range groups {
+			items := bestExitDisplayMapSlice(group)
+			if len(items) > 0 {
+				out = append(out, items)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func bestExitDisplayNodeName(source map[string]interface{}, nodeID int64, lookup bestExitNodeNameLookup, fallback string) string {
+	if source != nil {
+		for _, key := range []string{"nodeName", "name"} {
+			if name := strings.TrimSpace(asString(source[key])); name != "" {
+				return name
+			}
+		}
+	}
+	if lookup != nil {
+		if name, ok := lookup(nodeID); ok && strings.TrimSpace(name) != "" {
+			return strings.TrimSpace(name)
+		}
+	}
+	return fallback
+}
+
+func bestExitUnknownOwnerName(role string) string {
+	if role == "chain" {
+		return bestExitUnknownChainName
+	}
+	return bestExitUnknownEntryName
+}

--- a/go-backend/internal/http/handler/tunnel_best_exit_display_test.go
+++ b/go-backend/internal/http/handler/tunnel_best_exit_display_test.go
@@ -1,0 +1,383 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go-backend/internal/store/repo"
+)
+
+func TestBestExitDecisionSnapshotIsDefensiveCopy(t *testing.T) {
+	m := newBestExitManager()
+	key := bestExitOwnerKey{TunnelID: 77, OwnerNodeID: 10}
+	now := time.Unix(100, 0)
+	score := scoreBestExitCandidate(10, chainNodeRecord{NodeID: 30, NodeName: "exit-a"}, 10, 0, 20, 0)
+
+	m.observeScores(key, []bestExitCandidateScore{score}, now)
+	snapshot, ok := m.snapshot(key)
+	if !ok {
+		t.Fatalf("expected snapshot")
+	}
+	if snapshot.AppliedExitNodeID != 30 || snapshot.UpdatedAt != now.UnixMilli() {
+		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	}
+	if len(snapshot.Scores) != 1 {
+		t.Fatalf("expected one score in snapshot, got %+v", snapshot.Scores)
+	}
+	snapshot.Scores[0].ExitNodeID = 99
+
+	again, ok := m.snapshot(key)
+	if !ok {
+		t.Fatalf("expected second snapshot")
+	}
+	if again.Scores[0].ExitNodeID != 30 {
+		t.Fatalf("snapshot score mutation leaked into manager state: %+v", again.Scores)
+	}
+}
+
+func TestBuildBestExitDisplayStateForDirectMultiEntryOwners(t *testing.T) {
+	m := newBestExitManager()
+	now := time.Unix(100, 0)
+	m.setApplied(bestExitOwnerKey{TunnelID: 77, OwnerNodeID: 10}, 30, now)
+	m.setApplied(bestExitOwnerKey{TunnelID: 77, OwnerNodeID: 11}, 31, now.Add(time.Second))
+
+	tunnel := map[string]interface{}{
+		"id": int64(77),
+		"inNodeId": []map[string]interface{}{
+			{"nodeId": int64(10)},
+			{"nodeId": int64(11)},
+		},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": tunnelStrategyBest},
+			{"nodeId": int64(31), "strategy": tunnelStrategyBest},
+		},
+		"chainNodes": [][]map[string]interface{}{},
+	}
+	names := map[int64]string{10: "入口 A", 11: "入口 B", 30: "香港节点", 31: "日本节点"}
+
+	state, ok := buildBestExitDisplayState(tunnel, m, testBestExitNameLookup(names))
+	if !ok {
+		t.Fatalf("expected best exit state")
+	}
+	if !state.Enabled || state.Summary != "多个出口" || state.Status != "applied" {
+		t.Fatalf("unexpected state summary: %+v", state)
+	}
+	if state.UpdatedAt != now.Add(time.Second).UnixMilli() {
+		t.Fatalf("expected latest updatedAt, got %d", state.UpdatedAt)
+	}
+	if len(state.Items) != 2 {
+		t.Fatalf("expected two owner items, got %+v", state.Items)
+	}
+	if state.Items[0].OwnerRole != "entry" || state.Items[0].OwnerNodeName != "入口 A" || state.Items[0].ExitNodeName != "香港节点" {
+		t.Fatalf("unexpected first item: %+v", state.Items[0])
+	}
+	if state.Items[1].OwnerRole != "entry" || state.Items[1].OwnerNodeName != "入口 B" || state.Items[1].ExitNodeName != "日本节点" {
+		t.Fatalf("unexpected second item: %+v", state.Items[1])
+	}
+}
+
+func TestBuildBestExitDisplayStateForFinalChainHopOwners(t *testing.T) {
+	m := newBestExitManager()
+	now := time.Unix(200, 0)
+	m.setApplied(bestExitOwnerKey{TunnelID: 88, OwnerNodeID: 20}, 30, now)
+	m.setApplied(bestExitOwnerKey{TunnelID: 88, OwnerNodeID: 21}, 30, now.Add(time.Second))
+
+	tunnel := map[string]interface{}{
+		"id": int64(88),
+		"inNodeId": []map[string]interface{}{
+			{"nodeId": int64(10)},
+		},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": tunnelStrategyBest},
+			{"nodeId": int64(31), "strategy": tunnelStrategyBest},
+		},
+		"chainNodes": [][]map[string]interface{}{
+			{{"nodeId": int64(15), "inx": int64(0)}},
+			{{"nodeId": int64(20), "inx": int64(1)}, {"nodeId": int64(21), "inx": int64(1)}},
+		},
+	}
+	names := map[int64]string{20: "中转 M1", 21: "中转 M2", 30: "香港节点", 31: "日本节点"}
+
+	state, ok := buildBestExitDisplayState(tunnel, m, testBestExitNameLookup(names))
+	if !ok {
+		t.Fatalf("expected best exit state")
+	}
+	if state.Summary != "香港节点" || state.Status != "applied" {
+		t.Fatalf("expected single-exit summary, got %+v", state)
+	}
+	if len(state.Items) != 2 {
+		t.Fatalf("expected two final-hop owner items, got %+v", state.Items)
+	}
+	if state.Items[0].OwnerRole != "chain" || state.Items[0].OwnerNodeName != "中转 M1" || state.Items[0].ExitNodeName != "香港节点" {
+		t.Fatalf("unexpected first chain owner item: %+v", state.Items[0])
+	}
+	if state.Items[1].OwnerRole != "chain" || state.Items[1].OwnerNodeName != "中转 M2" || state.Items[1].ExitNodeName != "香港节点" {
+		t.Fatalf("unexpected second chain owner item: %+v", state.Items[1])
+	}
+}
+
+func TestBuildBestExitDisplayStateWaitingWhenNoAppliedDecisionExists(t *testing.T) {
+	tunnel := map[string]interface{}{
+		"id": int64(77),
+		"inNodeId": []map[string]interface{}{
+			{"nodeId": int64(10)},
+		},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": tunnelStrategyBest},
+			{"nodeId": int64(31), "strategy": tunnelStrategyBest},
+		},
+		"chainNodes": [][]map[string]interface{}{},
+	}
+	names := map[int64]string{10: "入口 A", 30: "香港节点", 31: "日本节点"}
+
+	state, ok := buildBestExitDisplayState(tunnel, newBestExitManager(), testBestExitNameLookup(names))
+	if !ok {
+		t.Fatalf("expected waiting best exit state")
+	}
+	if state.Summary != "等待探测" || state.Status != "waiting" {
+		t.Fatalf("expected waiting state, got %+v", state)
+	}
+	if len(state.Items) != 1 || state.Items[0].ExitNodeID != 0 || state.Items[0].ExitNodeName != "等待探测" {
+		t.Fatalf("unexpected waiting item: %+v", state.Items)
+	}
+}
+
+func TestBuildBestExitDisplayStateKeepsTopLevelWaitingWhenSomeOwnersPending(t *testing.T) {
+	m := newBestExitManager()
+	now := time.Unix(400, 0)
+	m.setApplied(bestExitOwnerKey{TunnelID: 77, OwnerNodeID: 10}, 30, now)
+
+	tunnel := map[string]interface{}{
+		"id": int64(77),
+		"inNodeId": []map[string]interface{}{
+			{"nodeId": int64(10)},
+			{"nodeId": int64(11)},
+		},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": tunnelStrategyBest},
+			{"nodeId": int64(31), "strategy": tunnelStrategyBest},
+		},
+		"chainNodes": [][]map[string]interface{}{},
+	}
+	names := map[int64]string{10: "入口 A", 11: "入口 B", 30: "香港节点", 31: "日本节点"}
+
+	state, ok := buildBestExitDisplayState(tunnel, m, testBestExitNameLookup(names))
+	if !ok {
+		t.Fatalf("expected best exit state")
+	}
+	if state.Status != bestExitDisplayStatusWaiting || state.Summary != bestExitDisplaySummaryWait {
+		t.Fatalf("expected top-level waiting for partial owner state, got %+v", state)
+	}
+	if len(state.Items) != 2 {
+		t.Fatalf("expected two owner items, got %+v", state.Items)
+	}
+	if state.Items[0].ExitNodeID != 30 || state.Items[0].ExitNodeName != "香港节点" {
+		t.Fatalf("expected first owner applied details to remain visible, got %+v", state.Items[0])
+	}
+	if state.Items[1].ExitNodeID != 0 || state.Items[1].ExitNodeName != bestExitDisplaySummaryWait {
+		t.Fatalf("expected second owner waiting details, got %+v", state.Items[1])
+	}
+}
+
+func TestBuildBestExitDisplayStateIgnoresAppliedExitRemovedFromTunnel(t *testing.T) {
+	m := newBestExitManager()
+	now := time.Unix(500, 0)
+	m.setApplied(bestExitOwnerKey{TunnelID: 77, OwnerNodeID: 10}, 99, now)
+
+	tunnel := map[string]interface{}{
+		"id": int64(77),
+		"inNodeId": []map[string]interface{}{
+			{"nodeId": int64(10)},
+		},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": tunnelStrategyBest},
+			{"nodeId": int64(31), "strategy": tunnelStrategyBest},
+		},
+		"chainNodes": [][]map[string]interface{}{},
+	}
+	names := map[int64]string{10: "入口 A", 30: "香港节点", 31: "日本节点", 99: "已删除节点"}
+
+	state, ok := buildBestExitDisplayState(tunnel, m, testBestExitNameLookup(names))
+	if !ok {
+		t.Fatalf("expected best exit state")
+	}
+	if state.Status != bestExitDisplayStatusWaiting || state.Summary != bestExitDisplaySummaryWait {
+		t.Fatalf("expected waiting state for stale applied exit, got %+v", state)
+	}
+	if len(state.Items) != 1 {
+		t.Fatalf("expected one item, got %+v", state.Items)
+	}
+	if state.Items[0].ExitNodeID != 0 || state.Items[0].ExitNodeName != bestExitDisplaySummaryWait {
+		t.Fatalf("expected stale exit to be ignored, got %+v", state.Items[0])
+	}
+}
+
+func TestBuildBestExitDisplayStateSkipsNonBestAndSingleExitTunnels(t *testing.T) {
+	nonBest := map[string]interface{}{
+		"id":       int64(77),
+		"inNodeId": []map[string]interface{}{{"nodeId": int64(10)}},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": "round"},
+			{"nodeId": int64(31), "strategy": "round"},
+		},
+	}
+	if state, ok := buildBestExitDisplayState(nonBest, newBestExitManager(), testBestExitNameLookup(nil)); ok || state != nil {
+		t.Fatalf("expected non-best tunnel to skip state, got %+v", state)
+	}
+
+	singleExit := map[string]interface{}{
+		"id":       int64(78),
+		"inNodeId": []map[string]interface{}{{"nodeId": int64(10)}},
+		"outNodeId": []map[string]interface{}{
+			{"nodeId": int64(30), "strategy": tunnelStrategyBest},
+		},
+	}
+	if state, ok := buildBestExitDisplayState(singleExit, newBestExitManager(), testBestExitNameLookup(nil)); ok || state != nil {
+		t.Fatalf("expected single-exit tunnel to skip state, got %+v", state)
+	}
+}
+
+func TestTunnelListAttachesBestExitStateOnlyForEligibleTunnels(t *testing.T) {
+	h := setupBestExitTunnelHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tunnel/list", nil)
+	res := httptest.NewRecorder()
+	h.tunnelList(res, req)
+
+	var payload struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}
+	decodeBestExitTunnelResponse(t, res, &payload)
+	if payload.Code != 0 {
+		t.Fatalf("expected success response, got code %d", payload.Code)
+	}
+
+	bestTunnel := findTunnelResponseItem(t, payload.Data, 77)
+	if _, ok := bestTunnel["bestExitState"]; !ok {
+		t.Fatalf("expected eligible best multi-exit tunnel to include bestExitState: %+v", bestTunnel)
+	}
+
+	singleExitTunnel := findTunnelResponseItem(t, payload.Data, 78)
+	if _, ok := singleExitTunnel["bestExitState"]; ok {
+		t.Fatalf("expected single-exit tunnel to omit bestExitState: %+v", singleExitTunnel)
+	}
+
+	nonBestTunnel := findTunnelResponseItem(t, payload.Data, 79)
+	if _, ok := nonBestTunnel["bestExitState"]; ok {
+		t.Fatalf("expected non-best tunnel to omit bestExitState: %+v", nonBestTunnel)
+	}
+}
+
+func TestTunnelGetAttachesBestExitStateToSelectedTunnel(t *testing.T) {
+	h := setupBestExitTunnelHandler(t)
+
+	body := bytes.NewReader([]byte(`{"id":77}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tunnel/get", body)
+	res := httptest.NewRecorder()
+	h.tunnelGet(res, req)
+
+	var payload struct {
+		Code int            `json:"code"`
+		Data map[string]any `json:"data"`
+	}
+	decodeBestExitTunnelResponse(t, res, &payload)
+	if payload.Code != 0 {
+		t.Fatalf("expected success response, got code %d", payload.Code)
+	}
+	if _, ok := payload.Data["bestExitState"]; !ok {
+		t.Fatalf("expected selected best multi-exit tunnel to include bestExitState: %+v", payload.Data)
+	}
+}
+
+func setupBestExitTunnelHandler(t *testing.T) *Handler {
+	t.Helper()
+	r, err := repo.Open(filepath.Join(t.TempDir(), "panel.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	h := New(r, "secret")
+	now := time.Now().UnixMilli()
+
+	insertNode := func(id int64, name string) {
+		t.Helper()
+		if err := r.DB().Exec(`
+			INSERT INTO node(id, name, secret, server_ip, server_ip_v4, server_ip_v6, port, interface_name, version, http, tls, socks, created_time, updated_time, status, tcp_listen_addr, udp_listen_addr, inx)
+			VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, id, name, name+"-secret", "10.0.0.1", "10.0.0.1", "", "30000-30010", "", "v1", 1, 1, 1, now, now, 1, "[::]", "[::]", 0).Error; err != nil {
+			t.Fatalf("insert node %s: %v", name, err)
+		}
+	}
+	insertNode(10, "entry-a")
+	insertNode(30, "exit-a")
+	insertNode(31, "exit-b")
+	insertNode(32, "exit-c")
+
+	insertTunnel := func(id int64, name string) {
+		t.Helper()
+		if err := r.DB().Exec(`
+			INSERT INTO tunnel(id, name, traffic_ratio, type, protocol, flow, created_time, updated_time, status, inx, ip_preference)
+			VALUES(?, ?, 1, 1, 'tls', 1, ?, ?, 1, ?, '')
+		`, id, name, now, now, id).Error; err != nil {
+			t.Fatalf("insert tunnel %s: %v", name, err)
+		}
+	}
+	insertTunnel(77, "best-multi")
+	insertTunnel(78, "best-single")
+	insertTunnel(79, "round-multi")
+
+	insertChain := func(tunnelID int64, chainType string, nodeID int64, strategy string, inx int64) {
+		t.Helper()
+		if err := r.DB().Exec(`
+			INSERT INTO chain_tunnel(tunnel_id, chain_type, node_id, port, strategy, inx, protocol)
+			VALUES(?, ?, ?, 30001, ?, ?, 'tls')
+		`, tunnelID, chainType, nodeID, strategy, inx).Error; err != nil {
+			t.Fatalf("insert chain tunnel %d/%s/%d: %v", tunnelID, chainType, nodeID, err)
+		}
+	}
+	insertChain(77, "1", 10, "round", 1)
+	insertChain(77, "3", 30, tunnelStrategyBest, 1)
+	insertChain(77, "3", 31, tunnelStrategyBest, 2)
+	insertChain(78, "1", 10, "round", 1)
+	insertChain(78, "3", 30, tunnelStrategyBest, 1)
+	insertChain(79, "1", 10, "round", 1)
+	insertChain(79, "3", 31, "round", 1)
+	insertChain(79, "3", 32, "round", 2)
+
+	h.bestExit.setApplied(bestExitOwnerKey{TunnelID: 77, OwnerNodeID: 10}, 30, time.UnixMilli(now))
+	return h
+}
+
+func decodeBestExitTunnelResponse(t *testing.T, res *httptest.ResponseRecorder, v any) {
+	t.Helper()
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected HTTP %d, got %d", http.StatusOK, res.Code)
+	}
+	if err := json.NewDecoder(res.Body).Decode(v); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+}
+
+func findTunnelResponseItem(t *testing.T, items []map[string]any, id float64) map[string]any {
+	t.Helper()
+	for _, item := range items {
+		if item["id"] == id {
+			return item
+		}
+	}
+	t.Fatalf("tunnel %.0f not found in response: %+v", id, items)
+	return nil
+}
+
+func testBestExitNameLookup(names map[int64]string) bestExitNodeNameLookup {
+	return func(nodeID int64) (string, bool) {
+		name := names[nodeID]
+		return name, name != ""
+	}
+}

--- a/vite-frontend/src/pages/tunnel.tsx
+++ b/vite-frontend/src/pages/tunnel.tsx
@@ -97,6 +97,25 @@ interface ChainTunnel {
   connectIp?: string; // 连接IP（多IP节点指定连接地址）
 }
 
+interface BestExitStateItem {
+  ownerNodeId: number;
+  ownerNodeName: string;
+  ownerRole: "entry" | "chain" | string;
+  exitNodeId?: number;
+  exitNodeName: string;
+  updatedAt?: number;
+  reason?: string;
+}
+
+interface BestExitState {
+  enabled: boolean;
+  summary: string;
+  status: "applied" | "waiting" | string;
+  updatedAt?: number;
+  reason?: string;
+  items: BestExitStateItem[];
+}
+
 interface Tunnel {
   id: number;
   inx?: number;
@@ -111,6 +130,7 @@ interface Tunnel {
   flow: number; // 1: 单向, 2: 双向
   trafficRatio: number;
   ipPreference?: string;
+  bestExitState?: BestExitState;
   status: number;
   createdTime: string;
 }
@@ -165,19 +185,128 @@ const DEFAULT_TUNNEL_DELETE_ACTION: TunnelDeleteAction = "replace";
 
 const TUNNEL_ORDER_KEY = "tunnel-order";
 
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value);
+
+const toSafeString = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return "";
+};
+
+const toSafeNumber = (value: unknown): number | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return undefined;
+
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const normalizeBestExitStateItem = (
+  value: unknown,
+): BestExitStateItem | undefined => {
+  if (!isObjectRecord(value)) return undefined;
+
+  const ownerNodeId = toSafeNumber(value.ownerNodeId);
+
+  if (ownerNodeId === undefined) return undefined;
+
+  const exitNodeId = toSafeNumber(value.exitNodeId);
+  const updatedAt = toSafeNumber(value.updatedAt);
+  const reason = toSafeString(value.reason);
+
+  return {
+    ownerNodeId,
+    ownerNodeName: toSafeString(value.ownerNodeName),
+    ownerRole: toSafeString(value.ownerRole),
+    ...(exitNodeId !== undefined ? { exitNodeId } : {}),
+    exitNodeName: toSafeString(value.exitNodeName),
+    ...(updatedAt !== undefined ? { updatedAt } : {}),
+    ...(reason ? { reason } : {}),
+  };
+};
+
+const normalizeBestExitState = (value: unknown): BestExitState | undefined => {
+  if (!isObjectRecord(value) || value.enabled !== true) return undefined;
+
+  const updatedAt = toSafeNumber(value.updatedAt);
+  const reason = toSafeString(value.reason);
+  const items = Array.isArray(value.items)
+    ? value.items.flatMap((item) => {
+        const normalized = normalizeBestExitStateItem(item);
+
+        return normalized ? [normalized] : [];
+      })
+    : [];
+
+  return {
+    enabled: true,
+    summary: toSafeString(value.summary),
+    status: toSafeString(value.status),
+    ...(updatedAt !== undefined ? { updatedAt } : {}),
+    ...(reason ? { reason } : {}),
+    items,
+  };
+};
+
+const bestExitOwnerRoleText = (role?: string) => {
+  if (role === "chain") return "中转";
+  return "入口";
+};
+
+const bestExitDetailTitle = (state?: BestExitState) => {
+  if (!state?.items?.length) return undefined;
+  return state.items
+    .map(
+      (item) =>
+        `${bestExitOwnerRoleText(item.ownerRole)} ${item.ownerNodeName || item.ownerNodeId} -> ${item.exitNodeName || "等待探测"}`,
+    )
+    .join("\n");
+};
+
+const renderBestExitState = (state?: BestExitState) => {
+  if (!state?.enabled) return null;
+
+  const isWaiting = state.status === "waiting";
+  const summaryText = state.summary || "等待探测";
+  const displaySummary =
+    isWaiting && !summaryText.includes("等待")
+      ? `等待探测 · ${summaryText}`
+      : summaryText;
+  const className = isWaiting
+    ? "border-warning-200/70 bg-warning-50/50 text-warning-700 dark:border-warning-300/20 dark:bg-warning-900/20 dark:text-warning-300"
+    : "border-success-200/60 bg-success-50/40 text-success-700 dark:border-success-300/20 dark:bg-success-900/20 dark:text-success-300";
+
+  return (
+    <span
+      className={`inline-flex max-w-full items-center rounded border px-1.5 py-0.5 text-[11px] leading-4 ${className}`}
+      title={bestExitDetailTitle(state)}
+    >
+      <span className="min-w-0 truncate">最优出口：{displaySummary}</span>
+    </span>
+  );
+};
+
 const mapTunnelApiItems = (items: any[]): Tunnel[] => {
-  return (items || []).map((tunnel) => ({
-    ...tunnel,
-    inx: tunnel.inx ?? 0,
-    inNodeId: Array.isArray(tunnel.inNodeId) ? tunnel.inNodeId : [],
-    outNodeId: Array.isArray(tunnel.outNodeId) ? tunnel.outNodeId : [],
-    chainNodes: Array.isArray(tunnel.chainNodes) ? tunnel.chainNodes : [],
-    inIp: tunnel.inIp || "",
-    flow: tunnel.flow ?? 1,
-    trafficRatio: tunnel.trafficRatio ?? 1,
-    status: typeof tunnel.status === "number" ? tunnel.status : 0,
-    createdTime: tunnel.createdTime || "",
-  }));
+  return (items || []).map((tunnel) => {
+    const { bestExitState: rawBestExitState, ...tunnelFields } = tunnel;
+    const bestExitState = normalizeBestExitState(rawBestExitState);
+
+    return {
+      ...tunnelFields,
+      ...(bestExitState ? { bestExitState } : {}),
+      inx: tunnel.inx ?? 0,
+      inNodeId: Array.isArray(tunnel.inNodeId) ? tunnel.inNodeId : [],
+      outNodeId: Array.isArray(tunnel.outNodeId) ? tunnel.outNodeId : [],
+      chainNodes: Array.isArray(tunnel.chainNodes) ? tunnel.chainNodes : [],
+      inIp: tunnel.inIp || "",
+      flow: tunnel.flow ?? 1,
+      trafficRatio: tunnel.trafficRatio ?? 1,
+      status: typeof tunnel.status === "number" ? tunnel.status : 0,
+      createdTime: tunnel.createdTime || "",
+    };
+  });
 };
 
 export default function TunnelPage() {
@@ -1636,6 +1765,9 @@ export default function TunnelPage() {
                     tunnel.type === 1
                       ? "text-[10px] h-5 bg-primary-100 text-primary-800 border-primary-300 dark:bg-primary-900/45 dark:text-primary-200 dark:border-primary-700"
                       : "text-[10px] h-5 bg-success-100 text-success-800 border-success-300 dark:bg-success-900/35 dark:text-success-200 dark:border-success-700";
+                  const bestExitStateContent = renderBestExitState(
+                    tunnel.bestExitState,
+                  );
 
                   return (
                     <TableRow key={tunnel.id}>
@@ -1672,24 +1804,27 @@ export default function TunnelPage() {
                         </Chip>
                       </TableCell>
                       <TableCell>
-                        <div className="flex items-center gap-1.5 text-xs">
-                          <span className="font-semibold text-primary-700 dark:text-primary-400">
-                            {tunnel.inNodeId?.length || 0}入口
-                          </span>
-                          <span className="text-default-400">→</span>
-                          <span className="font-semibold text-secondary-700 dark:text-secondary-400">
-                            {tunnel.type === 2
-                              ? tunnel.chainNodes?.length || 0
-                              : 0}
-                            跳
-                          </span>
-                          <span className="text-default-400">→</span>
-                          <span className="font-semibold text-success-700 dark:text-success-400">
-                            {tunnel.type === 2
-                              ? tunnel.outNodeId?.length || 0
-                              : tunnel.inNodeId?.length || 0}
-                            出口
-                          </span>
+                        <div className="flex min-w-0 flex-col gap-1.5">
+                          <div className="flex items-center gap-1.5 text-xs">
+                            <span className="font-semibold text-primary-700 dark:text-primary-400">
+                              {tunnel.inNodeId?.length || 0}入口
+                            </span>
+                            <span className="text-default-400">→</span>
+                            <span className="font-semibold text-secondary-700 dark:text-secondary-400">
+                              {tunnel.type === 2
+                                ? tunnel.chainNodes?.length || 0
+                                : 0}
+                              跳
+                            </span>
+                            <span className="text-default-400">→</span>
+                            <span className="font-semibold text-success-700 dark:text-success-400">
+                              {tunnel.type === 2
+                                ? tunnel.outNodeId?.length || 0
+                                : tunnel.inNodeId?.length || 0}
+                              出口
+                            </span>
+                          </div>
+                          {bestExitStateContent}
                         </div>
                       </TableCell>
                       <TableCell>
@@ -1758,6 +1893,9 @@ export default function TunnelPage() {
                     tunnel.type === 1
                       ? "text-xs bg-primary-100 text-primary-800 border-primary-300 dark:bg-primary-900/45 dark:text-primary-200 dark:border-primary-700"
                       : "text-xs bg-success-100 text-success-800 border-success-300 dark:bg-success-900/35 dark:text-success-200 dark:border-success-700";
+                  const bestExitStateContent = renderBestExitState(
+                    tunnel.bestExitState,
+                  );
 
                   return (
                     <SortableItem key={tunnel.id} id={tunnel.id}>
@@ -1908,6 +2046,11 @@ export default function TunnelPage() {
                                     </span>
                                   </div>
                                 </div>
+                                {bestExitStateContent && (
+                                  <div className="mt-2 flex min-w-0 justify-center">
+                                    {bestExitStateContent}
+                                  </div>
+                                )}
                               </div>
 
                               {/* 流量配置 */}


### PR DESCRIPTION
## Summary
- Add backend display-state snapshots and response enrichment for best multi-exit tunnels.
- Surface direct-entry and final-chain-hop owner choices, including waiting, partial, multi-exit, and stale-exit safeguards.
- Render compact current best-exit text in tunnel table/card views with native tooltip details.

## Test Plan
- [x] `rtk go test ./...` from `go-backend`
- [x] `pnpm run build` from `vite-frontend`