### PR TITLE
fix: upgrade Node.js to 22-alpine for corepack/pnpm compat

### DIFF
--- a/vite-frontend/Dockerfile
+++ b/vite-frontend/Dockerfile
@@ -1,5 +1,5 @@
 # 多阶段构建 - 构建阶段
-FROM node:20.19.0 AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Node.js 20.19.0 + corepack + pnpm@11.0.8 hits `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` during Docker build. Upgrade builder image to `node:22-alpine` (LTS).

## Verification

Frontend build passes locally with `pnpm run build`.