### PR TITLE
fix: approve @tailwindcss/oxide build script for pnpm v11

### DIFF
--- a/vite-frontend/Dockerfile
+++ b/vite-frontend/Dockerfile
@@ -4,7 +4,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml* ./
-RUN corepack enable pnpm && pnpm install --frozen-lockfile
+RUN corepack enable pnpm && pnpm config set onlyBuiltDependencies '["@tailwindcss/oxide"]' && pnpm install --frozen-lockfile
 
 COPY . .
 RUN pnpm run build


### PR DESCRIPTION
pnpm v11 blocks build scripts by default. Allow @tailwindcss/oxide via onlyBuiltDependencies.