### PR TITLE
fix: use .npmrc for pnpm onlyBuiltDependencies

### DIFF
--- a/vite-frontend/Dockerfile
+++ b/vite-frontend/Dockerfile
@@ -4,7 +4,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml* ./
-RUN corepack enable pnpm && pnpm config set onlyBuiltDependencies '["@tailwindcss/oxide"]' && pnpm install --frozen-lockfile
+RUN echo 'onlyBuiltDependencies[]=@tailwindcss/oxide' > .npmrc && corepack enable pnpm && pnpm install --frozen-lockfile
 
 COPY . .
 RUN pnpm run build


### PR DESCRIPTION
Use .npmrc file for pnpm v11 build scripts approval.