### PR TITLE
fix: use pnpm-workspace.yaml for onlyBuiltDependencies

### DIFF
--- a/vite-frontend/Dockerfile
+++ b/vite-frontend/Dockerfile
@@ -4,7 +4,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml* ./
-RUN echo 'onlyBuiltDependencies[]=@tailwindcss/oxide' > .npmrc && corepack enable pnpm && pnpm install --frozen-lockfile
+RUN echo 'onlyBuiltDependencies:' > pnpm-workspace.yaml && echo '  - "@tailwindcss/oxide"' >> pnpm-workspace.yaml && corepack enable pnpm && pnpm install --frozen-lockfile
 
 COPY . .
 RUN pnpm run build


### PR DESCRIPTION
Create pnpm-workspace.yaml inline in Dockerfile for pnpm v11 build scripts.