### PR TITLE
fix: pin pnpm to v10 in Dockerfile

### DIFF
--- a/vite-frontend/Dockerfile
+++ b/vite-frontend/Dockerfile
@@ -4,7 +4,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml* ./
-RUN echo 'onlyBuiltDependencies:' > pnpm-workspace.yaml && echo '  - "@tailwindcss/oxide"' >> pnpm-workspace.yaml && corepack enable pnpm && pnpm install --frozen-lockfile
+RUN corepack enable pnpm@10 && pnpm install --frozen-lockfile
 
 COPY . .
 RUN pnpm run build


### PR DESCRIPTION
Pin pnpm to v10 to avoid v11 build script issues in Docker build.