### PR TITLE
fix: Docker build pnpm/corepack compatibility

### DIFF
--- a/vite-frontend/Dockerfile
+++ b/vite-frontend/Dockerfile
@@ -4,7 +4,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml* ./
-RUN corepack enable pnpm@10 && pnpm install --frozen-lockfile
+RUN corepack prepare pnpm@10 --activate && corepack enable pnpm && pnpm install --frozen-lockfile
 
 COPY . .
 RUN pnpm run build


### PR DESCRIPTION
## Summary

- `node:20.19.0` + `corepack` + `pnpm@11` → `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`
- `pnpm@11` blocks `@tailwindcss/oxide` build scripts by default
- Fix: `node:22-alpine` + `corepack prepare pnpm@10 --activate && corepack enable pnpm`

## Verification (all local)

| Check | Result |
|-------|--------|
| `docker build ./vite-frontend` | ✅ |
| `go test ./...` | ✅ 498 passed |
| `pnpm run build` | ✅ |
| `pnpm run lint` | ✅ |