### PR TITLE
fix(node): allow IPv6-only addresses

### DIFF
--- a/go-backend/internal/http/handler/security_utils.go
+++ b/go-backend/internal/http/handler/security_utils.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"strings"
 )
 
@@ -74,6 +75,12 @@ func IsValidNodeAddress(addr string) error {
 	}
 	if strings.ContainsAny(addr, "/?") {
 		return fmt.Errorf("address must not contain path or query parameters")
+	}
+	// A bare IPv6 literal contains multiple colons, so net.SplitHostPort treats
+	// it as a malformed host:port pair. Accept IP literals before attempting
+	// host:port parsing; netip also handles scoped IPv6 addresses.
+	if _, err := netip.ParseAddr(addr); err == nil {
+		return nil
 	}
 
 	_, _, err := net.SplitHostPort(addr)

--- a/go-backend/internal/http/handler/security_utils_test.go
+++ b/go-backend/internal/http/handler/security_utils_test.go
@@ -1,0 +1,46 @@
+package handler
+
+import "testing"
+
+func TestIssue515IsValidNodeAddressAcceptsBareIPv6(t *testing.T) {
+	for _, addr := range []string{
+		"2001:db8::1",
+		"::1",
+		"fe80::1%eth0",
+	} {
+		t.Run(addr, func(t *testing.T) {
+			if err := IsValidNodeAddress(addr); err != nil {
+				t.Fatalf("expected bare IPv6 address %q to be accepted: %v", addr, err)
+			}
+		})
+	}
+}
+
+func TestIsValidNodeAddressKeepsExistingAddressForms(t *testing.T) {
+	for _, addr := range []string{
+		"203.0.113.10",
+		"node.example.com",
+		"node.example.com:6365",
+		"[2001:db8::1]:6365",
+	} {
+		t.Run(addr, func(t *testing.T) {
+			if err := IsValidNodeAddress(addr); err != nil {
+				t.Fatalf("expected node address %q to be accepted: %v", addr, err)
+			}
+		})
+	}
+}
+
+func TestIsValidNodeAddressRejectsURLComponents(t *testing.T) {
+	for _, addr := range []string{
+		"https://node.example.com",
+		"node.example.com/path",
+		"node.example.com?transport=tcp",
+	} {
+		t.Run(addr, func(t *testing.T) {
+			if err := IsValidNodeAddress(addr); err == nil {
+				t.Fatalf("expected node address %q to be rejected", addr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- accept bare IPv6 literals when validating node addresses
- preserve existing IPv4, hostname, and host:port handling
- add regression coverage for IPv6-only nodes, including scoped IPv6 addresses

## Root cause

`net.SplitHostPort` treats a bare IPv6 literal as a malformed host:port pair because it contains multiple colons. The validator now recognizes IP literals before attempting host:port parsing.

## Validation

- `go test ./internal/http/handler/...` (322 passed)
- `go test ./...` (692 passed)
- `git diff --check`

Closes #515