### PR TITLE
fix: accept existing license machine binding

### DIFF
--- a/go-backend/internal/http/handler/license_validation_test.go
+++ b/go-backend/internal/http/handler/license_validation_test.go
@@ -54,6 +54,41 @@ func TestValidateLicenseJobRepairsMissingMachineBinding(t *testing.T) {
 	}
 }
 
+func TestValidateLicenseJobAcceptsExistingMachineActivation(t *testing.T) {
+	r := openLicenseTestRepository(t)
+	now := time.Now().UnixMilli()
+	seedLicenseConfig(t, r, "license_key", "license-secret", now)
+	seedLicenseConfig(t, r, "is_commercial", "true", now)
+
+	var validations atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case strings.HasSuffix(req.URL.Path, "/licenses/actions/validate-key"):
+			if validations.Add(1) == 1 {
+				_, _ = fmt.Fprint(w, `{"meta":{"valid":false,"code":"NO_MACHINE"},"data":{"id":"license-id","attributes":{}}}`)
+				return
+			}
+			_, _ = fmt.Fprint(w, `{"meta":{"valid":true,"code":"VALID"},"data":{"id":"license-id","attributes":{"expiry":"never"}}}`)
+		case strings.HasSuffix(req.URL.Path, "/machines"):
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = fmt.Fprint(w, `{"errors":[{"code":"FINGERPRINT_TAKEN"},{"code":"MACHINE_LIMIT_EXCEEDED"}]}`)
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	defer server.Close()
+	restoreLicenseClientFactory(t, server.URL)
+
+	h := &Handler{repo: r}
+	h.validateLicenseJob()
+
+	assertLicenseConfig(t, r, "is_commercial", "true")
+	assertLicenseConfig(t, r, "license_expiry", "never")
+	if got := validations.Load(); got != 2 {
+		t.Fatalf("validation calls = %d, want 2", got)
+	}
+}
+
 func TestLicenseActivateRequiresSuccessfulPostActivationValidation(t *testing.T) {
 	r := openLicenseTestRepository(t)
 

--- a/go-backend/internal/license/keygen.go
+++ b/go-backend/internal/license/keygen.go
@@ -66,6 +66,25 @@ type ActivateMachineRequest struct {
 	} `json:"data"`
 }
 
+type keygenErrorResponse struct {
+	Errors []struct {
+		Code string `json:"code"`
+	} `json:"errors"`
+}
+
+func hasKeygenErrorCode(body []byte, code string) bool {
+	var resp keygenErrorResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return false
+	}
+	for _, item := range resp.Errors {
+		if strings.EqualFold(strings.TrimSpace(item.Code), code) {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *KeygenClient) ValidateKeyWithFingerprint(key string, fingerprint string) (*ValidateResponse, error) {
 	url := c.apiURL("licenses/actions/validate-key")
 
@@ -186,6 +205,11 @@ func (c *KeygenClient) ActivateMachine(licenseID, fingerprint string) error {
 	}
 
 	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusUnprocessableEntity && hasKeygenErrorCode(body, "FINGERPRINT_TAKEN") {
+		// Machine activation is idempotent. Keygen scopes fingerprint uniqueness
+		// to the target license, so this means the same machine is already bound.
+		return nil
+	}
 
 	return fmt.Errorf("failed to activate machine: status %d, response: %s", resp.StatusCode, string(body))
 }

--- a/go-backend/internal/license/keygen_test.go
+++ b/go-backend/internal/license/keygen_test.go
@@ -1,0 +1,40 @@
+package license
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestActivateMachineTreatsFingerprintTakenAsIdempotent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = fmt.Fprint(w, `{"errors":[{"code":"FINGERPRINT_TAKEN"},{"code":"MACHINE_LIMIT_EXCEEDED"}]}`)
+	}))
+	defer server.Close()
+
+	client := NewKeygenClient("account-id", "license-key")
+	client.BaseURL = server.URL
+
+	if err := client.ActivateMachine("license-id", "fingerprint"); err != nil {
+		t.Fatalf("ActivateMachine() error = %v, want idempotent success", err)
+	}
+}
+
+func TestActivateMachineRejectsMachineLimitWithoutFingerprintTaken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = fmt.Fprint(w, `{"errors":[{"code":"MACHINE_LIMIT_EXCEEDED"}]}`)
+	}))
+	defer server.Close()
+
+	client := NewKeygenClient("account-id", "license-key")
+	client.BaseURL = server.URL
+
+	err := client.ActivateMachine("license-id", "fingerprint")
+	if err == nil || !strings.Contains(err.Error(), "MACHINE_LIMIT_EXCEEDED") {
+		t.Fatalf("ActivateMachine() error = %v, want machine limit failure", err)
+	}
+}


### PR DESCRIPTION
## Summary

- treat Keygen `FINGERPRINT_TAKEN` activation responses as an idempotent existing-machine result
- continue with machine-scoped license validation after the idempotent activation response
- keep `MACHINE_LIMIT_EXCEEDED` as an error when `FINGERPRINT_TAKEN` is absent
- add client and handler regression coverage for the upgrade reactivation flow

## Root cause

After an upgrade, the panel can attempt to activate a machine fingerprint that Keygen already has bound to the same license. Keygen returns HTTP 422 with both `FINGERPRINT_TAKEN` and `MACHINE_LIMIT_EXCEEDED`; the client treated the entire response as a hard activation failure instead of continuing to validate the existing binding.

## Validation

- `go test ./...` (699 tests passed)